### PR TITLE
DirectX 11: Native renderer for Windows / Windows向けネイティブDirectX 11レンダラー

### DIFF
--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -413,6 +413,11 @@ pub fn add(
     step.linkLibC();
     step.addIncludePath(b.path("src/stb"));
     step.addCSourceFiles(.{ .files = &.{"src/stb/stb.c"} });
+    // DirectX 11 renderer C implementation
+    if (step.rootModuleTarget().os.tag == .windows) {
+        step.addCSourceFiles(.{ .files = &.{"src/renderer/directx/d3d11_impl.c"} });
+        step.addIncludePath(b.path("src/renderer/directx"));
+    }
     if (step.rootModuleTarget().os.tag == .linux) {
         step.addIncludePath(b.path("src/apprt/gtk"));
     }

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -18,6 +18,7 @@ pub const GenericRenderer = @import("renderer/generic.zig").Renderer;
 pub const Metal = @import("renderer/Metal.zig");
 pub const OpenGL = @import("renderer/OpenGL.zig");
 pub const WebGL = @import("renderer/WebGL.zig");
+pub const DirectX = @import("renderer/DirectX.zig");
 pub const Options = @import("renderer/Options.zig");
 pub const Overlay = @import("renderer/Overlay.zig");
 pub const Thread = @import("renderer/Thread.zig");
@@ -39,6 +40,7 @@ pub const Renderer = switch (build_config.renderer) {
     .metal => GenericRenderer(Metal),
     .opengl => GenericRenderer(OpenGL),
     .webgl => WebGL,
+    .directx => GenericRenderer(DirectX),
 };
 
 /// The health status of a renderer. These must be shared across all

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -40,8 +40,8 @@ fn dbgLog(msg: [*:0]const u8) void {
 
 /// Global device handle, accessible by Buffer/Texture/etc.
 pub var current_device: ?*anyopaque = null;
-/// Global shaders pointer for deferred device object creation.
-pub var pending_shader_init: ?*shaders.Shaders = null;
+/// HWND stored from surfaceInit for device creation in threadEnter.
+var stored_hwnd: ?*anyopaque = null;
 
 // C API from d3d11_impl.c
 pub const dx = struct {
@@ -106,12 +106,22 @@ pub fn deinit(self: *DirectX) void {
 }
 
 pub fn surfaceInit(surface: *apprt.Surface) !void {
-    // Create D3D11 device here. ID3D11Device is thread-safe for object creation
-    // (CreateVertexShader etc). Only ID3D11DeviceContext is single-threaded.
+    // Store HWND for device creation in threadEnter (must be on renderer thread).
     if (comptime builtin.os.tag != .windows) return;
-    const platform = surface.platform.windows;
-    const hwnd: ?*anyopaque = @ptrCast(platform.hwnd);
+    stored_hwnd = @ptrCast(surface.platform.windows.hwnd);
+    dbgLog("DirectX.surfaceInit: HWND stored\n");
+}
 
+pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
+    _ = self;
+    _ = surface;
+}
+
+pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
+    _ = surface;
+    // Create D3D11 device on renderer thread. The immediate context
+    // must only be used from this thread.
+    const hwnd = stored_hwnd orelse return;
     const w32 = struct {
         const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
         extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
@@ -122,25 +132,13 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
     const h: u32 = @intCast(rect.bottom - rect.top);
 
     const dev = dx.dx_create(hwnd, w, h) orelse {
-        dbgLog("DirectX.surfaceInit: FAILED to create device\n");
+        dbgLog("DirectX.threadEnter: FAILED to create device\n");
         return error.DirectXFailed;
     };
-    current_device = dev;
-    dbgLog("DirectX.surfaceInit: device created\n");
-}
-
-pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
-    _ = self;
-    _ = surface;
-}
-
-pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
-    _ = surface;
-    // Device was created in surfaceInit. Store reference for drawing.
-    // ID3D11DeviceContext calls must happen on this (renderer) thread.
     const self_mut: *DirectX = @constCast(self);
-    self_mut.device = current_device;
-    dbgLog("DirectX.threadEnter: renderer thread ready\n");
+    self_mut.device = dev;
+    current_device = dev;
+    dbgLog("DirectX.threadEnter: device created on renderer thread\n");
 }
 
 pub fn threadExit(self: *const DirectX) void {
@@ -151,6 +149,8 @@ pub fn displayRealized(self: *const DirectX) void {
     _ = self;
 }
 
+var test_pipeline_handle: ?*anyopaque = null;
+
 pub fn drawFrameStart(self: *DirectX) void {
     if (self.device) |dev| {
         var w: u32 = 0;
@@ -158,8 +158,25 @@ pub fn drawFrameStart(self: *DirectX) void {
         dx.dx_get_backbuffer_size(dev, &w, &h);
         dx.dx_set_viewport(dev, w, h);
         dx.dx_bind_backbuffer(dev);
-        // Red clear = debug marker (shader should overwrite with bg color)
-        dx.dx_clear(dev, 1.0, 0.0, 0.0, 1.0);
+        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
+        dx.dx_set_blend_enabled(dev, false);
+
+        // Direct test: compile and draw a green triangle
+        if (test_pipeline_handle == null) {
+            const src = @embedFile("shaders/hlsl/common.hlsl") ++ @embedFile("shaders/hlsl/bg_color.hlsl");
+            const vs = dx.dx_compile_shader(src.ptr, src.len, "vs_main", "vs_5_0");
+            const ps = dx.dx_compile_shader(src.ptr, src.len, "ps_main", "ps_5_0");
+            if (vs.bytecode != null and ps.bytecode != null) {
+                test_pipeline_handle = dx.dx_create_pipeline(dev, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
+                dx.dx_free_compiled_shader(vs);
+                dx.dx_free_compiled_shader(ps);
+                dbgLog("DirectX: test pipeline created\n");
+            }
+        }
+        if (test_pipeline_handle) |pipe| {
+            dx.dx_bind_pipeline(dev, pipe);
+            dx.dx_draw(dev, 3, 0);
+        }
     }
 }
 
@@ -184,11 +201,10 @@ pub fn initShaders(
     alloc: Allocator,
     custom_shaders: []const [:0]const u8,
 ) !shaders.Shaders {
-    const dev = current_device;
-    dbgLog(if (dev != null) "DirectX.initShaders: device OK, compiling\n" else "DirectX.initShaders: no device!\n");
+    dbgLog("DirectX.initShaders: compiling HLSL bytecode (no device)\n");
     var s = try shaders.Shaders.init(alloc, custom_shaders);
     s.compileBytecode();
-    s.createDeviceObjects(dev);
+    // Device objects created later in threadEnter via drawFrameStart
     return s;
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -37,6 +37,8 @@ const log = std.log.scoped(.directx);
 pub var current_device: ?*anyopaque = null;
 /// HWND stored from surfaceInit for device creation in threadEnter.
 pub var stored_hwnd: ?*anyopaque = null;
+/// Stop flag for native render loop (set by stop.notify via Thread.zig).
+pub var stop_requested: std.atomic.Value(bool) = .{ .raw = false };
 
 // C API from d3d11_impl.c
 pub const dx = struct {
@@ -100,6 +102,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
 }
 
 pub fn deinit(self: *DirectX) void {
+    stop_requested.store(true, .monotonic);
     if (self.device) |dev| dx.dx_destroy(dev);
     self.* = undefined;
 }
@@ -163,10 +166,27 @@ pub fn drawFrameEnd(self: *DirectX) void {
 pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
     _ = self;
     const dev = current_device orelse return .{ .width = 960, .height = 640 };
-    var w: u32 = 0;
-    var h: u32 = 0;
-    dx.dx_get_backbuffer_size(dev, &w, &h);
-    if (w == 0 or h == 0) return .{ .width = 960, .height = 640 };
+    const hwnd = stored_hwnd orelse return .{ .width = 960, .height = 640 };
+
+    // Get actual window client size and resize swap chain if needed.
+    // Safe to call from the native render loop (no xev IOCP interference).
+    const w32 = struct {
+        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
+        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
+    };
+    var rect: w32.RECT = undefined;
+    _ = w32.GetClientRect(hwnd, &rect);
+    const w: u32 = @intCast(@max(rect.right - rect.left, 1));
+    const h: u32 = @intCast(@max(rect.bottom - rect.top, 1));
+
+    // Resize swap chain if window size changed
+    var bbw: u32 = 0;
+    var bbh: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &bbw, &bbh);
+    if (bbw != w or bbh != h) {
+        dx.dx_resize(dev, w, h);
+    }
+
     return .{ .width = w, .height = h };
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -150,7 +150,7 @@ pub fn drawFrameStart(self: *DirectX) void {
         dx.dx_bind_backbuffer(dev);
         dx.dx_set_blend_enabled(dev, false);
         dx.dx_ensure_default_sampler(dev);
-        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
+        dx.dx_clear(dev, 0.0, 0.0, 1.0, 1.0); // Blue = debug
     }
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -69,6 +69,7 @@ pub const dx = struct {
     pub extern fn dx_bind_sampler(?*anyopaque, ?*anyopaque, u32) void;
 
     pub extern fn dx_create_pipeline(?*anyopaque, ?*anyopaque, u32, ?*anyopaque, u32, ?*anyopaque, u32) ?*anyopaque;
+    pub extern fn dx_create_cell_text_pipeline(?*anyopaque, ?*anyopaque, u32, ?*anyopaque, u32) ?*anyopaque;
     pub extern fn dx_destroy_pipeline(?*anyopaque) void;
     pub extern fn dx_bind_pipeline(?*anyopaque, ?*anyopaque) void;
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -29,6 +29,9 @@ pub const swap_chain_count = 2;
 
 const log = std.log.scoped(.directx);
 
+/// Thread-local device handle, accessible by Buffer/Texture/etc.
+pub threadlocal var current_device: ?*anyopaque = null;
+
 // C API from d3d11_impl.c
 pub const dx = struct {
     pub extern fn dx_create(?*anyopaque, u32, u32) ?*anyopaque;
@@ -122,6 +125,7 @@ pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
     };
     const self_mut: *DirectX = @constCast(self);
     self_mut.device = dev;
+    current_device = dev;
     log.info("D3D11 device created ({d}x{d})", .{ w, h });
 }
 
@@ -135,8 +139,11 @@ pub fn displayRealized(self: *const DirectX) void {
 
 pub fn drawFrameStart(self: *DirectX) void {
     if (self.device) |dev| {
+        var w: u32 = 0;
+        var h: u32 = 0;
+        dx.dx_get_backbuffer_size(dev, &w, &h);
+        dx.dx_set_viewport(dev, w, h);
         dx.dx_bind_backbuffer(dev);
-        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
     }
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -49,6 +49,7 @@ pub const dx = struct {
     pub extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
     pub extern fn dx_draw(?*anyopaque, u32, u32, u32) void;
     pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32, u32) void;
+    pub extern fn dx_test_draw(?*anyopaque) void;
 
     pub const CompiledShader = extern struct { bytecode: ?*anyopaque, size: u32 };
     pub extern fn dx_compile_shader(?[*]const u8, u32, [*:0]const u8, [*:0]const u8) CompiledShader;
@@ -86,6 +87,7 @@ alloc: std.mem.Allocator,
 blending: configpkg.Config.AlphaBlending,
 last_target: ?Target = null,
 device: ?*anyopaque = null,
+frame_rendered: bool = false,
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
     log.info("initializing DirectX 11 renderer", .{});
@@ -142,32 +144,33 @@ pub fn displayRealized(self: *const DirectX) void {
 }
 
 pub fn drawFrameStart(self: *DirectX) void {
-    if (self.device) |dev| {
-        var w: u32 = 0;
-        var h: u32 = 0;
-        dx.dx_get_backbuffer_size(dev, &w, &h);
-        dx.dx_set_viewport(dev, w, h);
-        dx.dx_bind_backbuffer(dev);
-        dx.dx_set_blend_enabled(dev, false);
-        dx.dx_ensure_default_sampler(dev);
-        dx.dx_clear(dev, 0.0, 0.0, 1.0, 1.0); // Blue = debug
-    }
+    self.frame_rendered = false;
+    // Use global device - self.device may not persist due to value copy semantics
+    const dev = current_device orelse return;
+    self.device = dev;
+    var w: u32 = 0;
+    var h: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &w, &h);
+    dx.dx_set_viewport(dev, w, h);
+    dx.dx_bind_backbuffer(dev);
+    dx.dx_set_blend_enabled(dev, false);
+    dx.dx_ensure_default_sampler(dev);
+    dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
 }
 
 pub fn drawFrameEnd(self: *DirectX) void {
-    if (self.device) |dev| {
-        dx.dx_present(dev, false);
-    }
+    const dev = current_device orelse return;
+    self.frame_rendered = true;
+    dx.dx_present(dev, false);
 }
 
 pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
-    if (self.device) |dev| {
-        var w: u32 = 0;
-        var h: u32 = 0;
-        dx.dx_get_backbuffer_size(dev, &w, &h);
-        return .{ .width = w, .height = h };
-    }
-    return .{ .width = 960, .height = 640 };
+    _ = self;
+    const dev = current_device orelse return .{ .width = 960, .height = 640 };
+    var w: u32 = 0;
+    var h: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &w, &h);
+    return .{ .width = w, .height = h };
 }
 
 pub fn initShaders(
@@ -199,9 +202,10 @@ pub fn present(self: *DirectX, target: Target) !void {
 }
 
 pub fn presentLastTarget(self: *DirectX) !void {
-    if (self.device) |dev| {
-        dx.dx_present(dev, false);
-    }
+    // With DXGI_SWAP_EFFECT_DISCARD, backbuffer content is undefined after Present.
+    // We can't re-present the last frame. Just present what's there.
+    // The real fix is to always redraw, but for now this avoids a second Present call.
+    _ = self;
 }
 
 pub fn initAtlasTexture(self: *const DirectX, atlas: anytype) !Texture {

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -27,6 +27,12 @@ pub const custom_shader_target: shadertoy.Target = .glsl;
 pub const custom_shader_y_is_down = true;
 pub const swap_chain_count = 2;
 
+/// Called from C++ WM_SIZE to update window size without cross-thread deadlock.
+export fn dx_notify_resize(w: u32, h: u32) void {
+    dx.dx_set_window_size(w, h);
+}
+
+
 /// Use a native Windows render loop instead of xev.
 /// xev's IOCP event loop stalls after D3D11 device creation.
 pub const native_render_loop = true;
@@ -37,7 +43,7 @@ const log = std.log.scoped(.directx);
 pub var current_device: ?*anyopaque = null;
 /// HWND stored from surfaceInit for device creation in threadEnter.
 pub var stored_hwnd: ?*anyopaque = null;
-/// Stop flag for native render loop (set by stop.notify via Thread.zig).
+/// Stop flag for native render loop.
 pub var stop_requested: std.atomic.Value(bool) = .{ .raw = false };
 
 // C API from d3d11_impl.c
@@ -55,6 +61,8 @@ pub const dx = struct {
     pub extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
     pub extern fn dx_draw(?*anyopaque, u32, u32, u32) void;
     pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32, u32) void;
+    pub extern fn dx_set_window_size(u32, u32) void;
+    pub extern fn dx_get_window_size(*u32, *u32) void;
 
     pub const CompiledShader = extern struct { bytecode: ?*anyopaque, size: u32 };
     pub extern fn dx_compile_shader(?[*]const u8, u32, [*:0]const u8, [*:0]const u8) CompiledShader;
@@ -109,7 +117,20 @@ pub fn deinit(self: *DirectX) void {
 
 pub fn surfaceInit(surface: *apprt.Surface) !void {
     if (comptime builtin.os.tag != .windows) return;
-    stored_hwnd = @ptrCast(surface.platform.windows.hwnd);
+    const hwnd: ?*anyopaque = @ptrCast(surface.platform.windows.hwnd);
+    stored_hwnd = hwnd;
+
+    // Set initial window size (main thread, safe to call GetClientRect here)
+    const w32 = struct {
+        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
+        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
+    };
+    var rect: w32.RECT = undefined;
+    _ = w32.GetClientRect(hwnd, &rect);
+    dx.dx_set_window_size(
+        @intCast(@max(rect.right - rect.left, 1)),
+        @intCast(@max(rect.bottom - rect.top, 1)),
+    );
 }
 
 pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
@@ -166,27 +187,27 @@ pub fn drawFrameEnd(self: *DirectX) void {
 pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
     _ = self;
     const dev = current_device orelse return .{ .width = 960, .height = 640 };
-    const hwnd = stored_hwnd orelse return .{ .width = 960, .height = 640 };
 
-    // Get actual window client size and resize swap chain if needed.
-    // Safe to call from the native render loop (no xev IOCP interference).
-    const w32 = struct {
-        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
-        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
-    };
-    var rect: w32.RECT = undefined;
-    _ = w32.GetClientRect(hwnd, &rect);
-    const w: u32 = @intCast(@max(rect.right - rect.left, 1));
-    const h: u32 = @intCast(@max(rect.bottom - rect.top, 1));
-
-    // Resize swap chain if window size changed
-    var bbw: u32 = 0;
-    var bbh: u32 = 0;
-    dx.dx_get_backbuffer_size(dev, &bbw, &bbh);
-    if (bbw != w or bbh != h) {
-        dx.dx_resize(dev, w, h);
+    // Read window size set by main thread (WM_SIZE → dx_notify_resize).
+    // Cannot call GetClientRect from renderer thread (cross-thread deadlock).
+    var ww: u32 = 0;
+    var wh: u32 = 0;
+    dx.dx_get_window_size(&ww, &wh);
+    if (ww > 0 and wh > 0) {
+        var bbw: u32 = 0;
+        var bbh: u32 = 0;
+        dx.dx_get_backbuffer_size(dev, &bbw, &bbh);
+        if (bbw != ww or bbh != wh) {
+            dx.dx_resize(dev, ww, wh);
+        }
+        return .{ .width = ww, .height = wh };
     }
 
+    // Fallback to backbuffer size
+    var w: u32 = 0;
+    var h: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &w, &h);
+    if (w == 0 or h == 0) return .{ .width = 960, .height = 640 };
     return .{ .width = w, .height = h };
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -1,0 +1,196 @@
+//! Graphics API wrapper for DirectX 11.
+//! This is a native Windows renderer that translates the Ghostty renderer
+//! interface to Direct3D 11 API calls.
+pub const DirectX = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const builtin = @import("builtin");
+const shadertoy = @import("shadertoy.zig");
+const apprt = @import("../apprt.zig");
+const font = @import("../font/main.zig");
+const configpkg = @import("../config.zig");
+const rendererpkg = @import("../renderer.zig");
+const Renderer = rendererpkg.GenericRenderer(DirectX);
+
+pub const GraphicsAPI = DirectX;
+pub const Target = @import("directx/Target.zig");
+pub const Frame = @import("directx/Frame.zig");
+pub const RenderPass = @import("directx/RenderPass.zig");
+pub const Pipeline = @import("directx/Pipeline.zig");
+const bufferpkg = @import("directx/buffer.zig");
+pub const Buffer = bufferpkg.Buffer;
+pub const Sampler = @import("directx/Sampler.zig");
+pub const Texture = @import("directx/Texture.zig");
+pub const shaders = @import("directx/shaders.zig");
+
+pub const custom_shader_target: shadertoy.Target = .glsl;
+// DirectX uses Y-down coordinate system (same as Metal)
+pub const custom_shader_y_is_down = true;
+
+/// DirectX uses a swap chain for presentation (double buffering)
+pub const swap_chain_count = 2;
+
+const log = std.log.scoped(.directx);
+
+alloc: std.mem.Allocator,
+
+/// Alpha blending mode
+blending: configpkg.Config.AlphaBlending,
+
+/// The most recently presented target
+last_target: ?Target = null,
+
+// TODO: Direct3D 11 resources
+// device: *ID3D11Device,
+// context: *ID3D11DeviceContext,
+// swap_chain: *IDXGISwapChain,
+
+pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
+    log.info("initializing DirectX 11 renderer", .{});
+    return .{
+        .alloc = alloc,
+        .blending = opts.config.blending,
+    };
+}
+
+pub fn deinit(self: *DirectX) void {
+    self.* = undefined;
+}
+
+pub fn surfaceInit(surface: *apprt.Surface) !void {
+    _ = surface;
+    // TODO: Create D3D11 device and swap chain from HWND
+    log.info("DirectX surface init", .{});
+}
+
+pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
+    _ = self;
+    _ = surface;
+}
+
+pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
+    _ = self;
+    _ = surface;
+    // TODO: D3D11 is single-threaded by default, may need deferred context
+}
+
+pub fn threadExit(self: *const DirectX) void {
+    _ = self;
+}
+
+pub fn displayRealized(self: *const DirectX) void {
+    _ = self;
+}
+
+pub fn drawFrameStart(self: *DirectX) void {
+    _ = self;
+    // TODO: Begin frame, clear render target
+}
+
+pub fn drawFrameEnd(self: *DirectX) void {
+    _ = self;
+    // TODO: Present swap chain
+}
+
+pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
+    _ = self;
+    // TODO: Query swap chain back buffer size
+    return .{ .width = 960, .height = 640 };
+}
+
+pub fn initShaders(
+    self: *const DirectX,
+    alloc: Allocator,
+    custom_shaders: []const [:0]const u8,
+) !shaders.Shaders {
+    _ = self;
+    return try shaders.Shaders.init(alloc, custom_shaders);
+}
+
+pub fn initTarget(self: *const DirectX, width: usize, height: usize) !Target {
+    return Target.init(.{
+        .internal_format = if (self.blending.isLinear()) .srgba else .rgba,
+        .width = width,
+        .height = height,
+    });
+}
+
+pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
+    _ = self;
+    return Frame.begin(renderer, target);
+}
+
+pub fn present(self: *DirectX, target: Target) !void {
+    self.last_target = target;
+    // TODO: Present to swap chain
+}
+
+pub fn presentLastTarget(self: *DirectX) !void {
+    _ = self;
+    // TODO: Re-present previous frame
+}
+
+pub fn initAtlasTexture(self: *const DirectX, atlas: anytype) !Texture {
+    _ = self;
+    const format: Texture.Options.Format = switch (atlas.format) {
+        .grayscale => .red,
+        .bgra => .bgra,
+        else => .rgba,
+    };
+    return Texture.init(.{
+        .format = format,
+    }, atlas.size, atlas.size, atlas.data);
+}
+
+pub fn initTexture(self: *const DirectX, opts: anytype) !Texture {
+    _ = self;
+    return Texture.init(.{}, opts.width, opts.height, opts.data);
+}
+
+pub inline fn bufferOptions(self: DirectX) bufferpkg.Options {
+    _ = self;
+    return .{ .target = .array, .usage = .dynamic_draw };
+}
+
+pub inline fn uniformBufferOptions(self: DirectX) bufferpkg.Options {
+    _ = self;
+    return .{ .target = .uniform, .usage = .dynamic_draw };
+}
+
+pub inline fn fgBufferOptions(self: DirectX) bufferpkg.Options {
+    _ = self;
+    return .{ .target = .shader_storage, .usage = .dynamic_draw };
+}
+
+pub inline fn bgBufferOptions(self: DirectX) bufferpkg.Options {
+    _ = self;
+    return .{ .target = .shader_storage, .usage = .dynamic_draw };
+}
+
+pub inline fn bgImageBufferOptions(self: DirectX) bufferpkg.Options {
+    _ = self;
+    return .{ .target = .array, .usage = .dynamic_draw };
+}
+
+pub inline fn imageBufferOptions(self: DirectX) bufferpkg.Options {
+    _ = self;
+    return .{ .target = .array, .usage = .dynamic_draw };
+}
+
+pub inline fn imageTextureOptions(self: DirectX, format: anytype, linear: bool) Texture.Options {
+    _ = self;
+    _ = format;
+    _ = linear;
+    return .{};
+}
+
+pub inline fn textureOptions(self: DirectX) Texture.Options {
+    _ = self;
+    return .{};
+}
+
+pub inline fn samplerOptions(self: DirectX) Sampler.Options {
+    _ = self;
+    return .{};
+}

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -29,7 +29,7 @@ pub const swap_chain_count = 2;
 
 const log = std.log.scoped(.directx);
 
-fn dbgLog(msg: [*:0]const u8) void {
+pub fn dbgLog(msg: [*:0]const u8) void {
     if (comptime builtin.os.tag == .windows) {
         const k32 = struct {
             extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
@@ -149,8 +149,6 @@ pub fn displayRealized(self: *const DirectX) void {
     _ = self;
 }
 
-var test_pipeline_handle: ?*anyopaque = null;
-
 pub fn drawFrameStart(self: *DirectX) void {
     if (self.device) |dev| {
         var w: u32 = 0;
@@ -158,25 +156,8 @@ pub fn drawFrameStart(self: *DirectX) void {
         dx.dx_get_backbuffer_size(dev, &w, &h);
         dx.dx_set_viewport(dev, w, h);
         dx.dx_bind_backbuffer(dev);
-        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
         dx.dx_set_blend_enabled(dev, false);
-
-        // Direct test: compile and draw a green triangle
-        if (test_pipeline_handle == null) {
-            const src = @embedFile("shaders/hlsl/common.hlsl") ++ @embedFile("shaders/hlsl/bg_color.hlsl");
-            const vs = dx.dx_compile_shader(src.ptr, src.len, "vs_main", "vs_5_0");
-            const ps = dx.dx_compile_shader(src.ptr, src.len, "ps_main", "ps_5_0");
-            if (vs.bytecode != null and ps.bytecode != null) {
-                test_pipeline_handle = dx.dx_create_pipeline(dev, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
-                dx.dx_free_compiled_shader(vs);
-                dx.dx_free_compiled_shader(ps);
-                dbgLog("DirectX: test pipeline created\n");
-            }
-        }
-        if (test_pipeline_handle) |pipe| {
-            dx.dx_bind_pipeline(dev, pipe);
-            dx.dx_draw(dev, 3, 0);
-        }
+        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
     }
 }
 
@@ -203,7 +184,7 @@ pub fn initShaders(
 ) !shaders.Shaders {
     dbgLog("DirectX.initShaders: compiling HLSL bytecode (no device)\n");
     var s = try shaders.Shaders.init(alloc, custom_shaders);
-    s.compileBytecode();
+    s.storeSource();
     // Device objects created later in threadEnter via drawFrameStart
     return s;
 }

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -1,6 +1,5 @@
 //! Graphics API wrapper for DirectX 11.
-//! This is a native Windows renderer that translates the Ghostty renderer
-//! interface to Direct3D 11 API calls.
+//! Uses a C implementation (d3d11_impl.c) for the COM-based D3D11 API.
 pub const DirectX = @This();
 
 const std = @import("std");
@@ -25,26 +24,50 @@ pub const Texture = @import("directx/Texture.zig");
 pub const shaders = @import("directx/shaders.zig");
 
 pub const custom_shader_target: shadertoy.Target = .glsl;
-// DirectX uses Y-down coordinate system (same as Metal)
 pub const custom_shader_y_is_down = true;
-
-/// DirectX uses a swap chain for presentation (double buffering)
 pub const swap_chain_count = 2;
 
 const log = std.log.scoped(.directx);
 
+// C API from d3d11_impl.c
+pub const dx = struct {
+    extern fn dx_create(?*anyopaque, u32, u32) ?*anyopaque;
+    extern fn dx_destroy(?*anyopaque) void;
+    extern fn dx_resize(?*anyopaque, u32, u32) void;
+    extern fn dx_present(?*anyopaque, bool) void;
+    extern fn dx_clear(?*anyopaque, f32, f32, f32, f32) void;
+    extern fn dx_set_viewport(?*anyopaque, u32, u32) void;
+    extern fn dx_bind_backbuffer(?*anyopaque) void;
+    extern fn dx_set_blend_enabled(?*anyopaque, bool) void;
+    extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
+    extern fn dx_draw(?*anyopaque, u32, u32) void;
+    extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32) void;
+
+    extern fn dx_create_buffer(?*anyopaque, u32, u32, ?*const anyopaque) ?*anyopaque;
+    extern fn dx_destroy_buffer(?*anyopaque) void;
+    extern fn dx_update_buffer(?*anyopaque, ?*anyopaque, ?*const anyopaque, u32) void;
+    extern fn dx_bind_vertex_buffer(?*anyopaque, ?*anyopaque, u32, u32) void;
+    extern fn dx_bind_constant_buffer(?*anyopaque, ?*anyopaque, u32, bool, bool) void;
+    extern fn dx_bind_srv_buffer(?*anyopaque, ?*anyopaque, u32, u32) void;
+
+    extern fn dx_create_texture(?*anyopaque, u32, u32, u32, ?*const anyopaque) ?*anyopaque;
+    extern fn dx_destroy_texture(?*anyopaque) void;
+    extern fn dx_update_texture_region(?*anyopaque, ?*anyopaque, u32, u32, u32, u32, ?*const anyopaque) void;
+    extern fn dx_bind_texture(?*anyopaque, ?*anyopaque, u32) void;
+
+    extern fn dx_create_sampler(?*anyopaque, u32, u32) ?*anyopaque;
+    extern fn dx_destroy_sampler(?*anyopaque) void;
+    extern fn dx_bind_sampler(?*anyopaque, ?*anyopaque, u32) void;
+
+    extern fn dx_create_render_target(?*anyopaque, u32, u32, u32) ?*anyopaque;
+    extern fn dx_destroy_render_target(?*anyopaque) void;
+    extern fn dx_bind_render_target(?*anyopaque, ?*anyopaque) void;
+};
+
 alloc: std.mem.Allocator,
-
-/// Alpha blending mode
 blending: configpkg.Config.AlphaBlending,
-
-/// The most recently presented target
 last_target: ?Target = null,
-
-// TODO: Direct3D 11 resources
-// device: *ID3D11Device,
-// context: *ID3D11DeviceContext,
-// swap_chain: *IDXGISwapChain,
+device: ?*anyopaque = null,
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
     log.info("initializing DirectX 11 renderer", .{});
@@ -55,13 +78,13 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
 }
 
 pub fn deinit(self: *DirectX) void {
+    if (self.device) |dev| dx.dx_destroy(dev);
     self.* = undefined;
 }
 
 pub fn surfaceInit(surface: *apprt.Surface) !void {
     _ = surface;
-    // TODO: Create D3D11 device and swap chain from HWND
-    log.info("DirectX surface init", .{});
+    log.info("DirectX surfaceInit (device created in threadEnter)", .{});
 }
 
 pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
@@ -70,9 +93,28 @@ pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void 
 }
 
 pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
-    _ = self;
-    _ = surface;
-    // TODO: D3D11 is single-threaded by default, may need deferred context
+    // DirectX is Windows-only
+    if (comptime builtin.os.tag != .windows) return;
+
+    const platform = surface.platform.windows;
+    const hwnd: ?*anyopaque = @ptrCast(platform.hwnd);
+
+    const win32 = struct {
+        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
+        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
+    };
+    var rect: win32.RECT = undefined;
+    _ = win32.GetClientRect(hwnd, &rect);
+    const w: u32 = @intCast(rect.right - rect.left);
+    const h: u32 = @intCast(rect.bottom - rect.top);
+
+    const dev = dx.dx_create(hwnd, w, h) orelse {
+        log.err("failed to create D3D11 device", .{});
+        return error.DirectXFailed;
+    };
+    const self_mut: *DirectX = @constCast(self);
+    self_mut.device = dev;
+    log.info("D3D11 device created ({d}x{d})", .{ w, h });
 }
 
 pub fn threadExit(self: *const DirectX) void {
@@ -84,18 +126,25 @@ pub fn displayRealized(self: *const DirectX) void {
 }
 
 pub fn drawFrameStart(self: *DirectX) void {
-    _ = self;
-    // TODO: Begin frame, clear render target
+    if (self.device) |dev| {
+        dx.dx_bind_backbuffer(dev);
+        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
+    }
 }
 
 pub fn drawFrameEnd(self: *DirectX) void {
-    _ = self;
-    // TODO: Present swap chain
+    if (self.device) |dev| {
+        dx.dx_present(dev, false);
+    }
 }
 
 pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
-    _ = self;
-    // TODO: Query swap chain back buffer size
+    if (self.device) |dev| {
+        var w: u32 = 0;
+        var h: u32 = 0;
+        dx.dx_get_backbuffer_size(dev, &w, &h);
+        return .{ .width = w, .height = h };
+    }
     return .{ .width = 960, .height = 640 };
 }
 
@@ -123,12 +172,12 @@ pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
 
 pub fn present(self: *DirectX, target: Target) !void {
     self.last_target = target;
-    // TODO: Present to swap chain
 }
 
 pub fn presentLastTarget(self: *DirectX) !void {
-    _ = self;
-    // TODO: Re-present previous frame
+    if (self.device) |dev| {
+        dx.dx_present(dev, false);
+    }
 }
 
 pub fn initAtlasTexture(self: *const DirectX, atlas: anytype) !Texture {
@@ -138,9 +187,7 @@ pub fn initAtlasTexture(self: *const DirectX, atlas: anytype) !Texture {
         .bgra => .bgra,
         else => .rgba,
     };
-    return Texture.init(.{
-        .format = format,
-    }, atlas.size, atlas.size, atlas.data);
+    return Texture.init(.{ .format = format }, atlas.size, atlas.size, atlas.data);
 }
 
 pub fn initTexture(self: *const DirectX, opts: anytype) !Texture {

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -31,37 +31,45 @@ const log = std.log.scoped(.directx);
 
 // C API from d3d11_impl.c
 pub const dx = struct {
-    extern fn dx_create(?*anyopaque, u32, u32) ?*anyopaque;
-    extern fn dx_destroy(?*anyopaque) void;
-    extern fn dx_resize(?*anyopaque, u32, u32) void;
-    extern fn dx_present(?*anyopaque, bool) void;
-    extern fn dx_clear(?*anyopaque, f32, f32, f32, f32) void;
-    extern fn dx_set_viewport(?*anyopaque, u32, u32) void;
-    extern fn dx_bind_backbuffer(?*anyopaque) void;
-    extern fn dx_set_blend_enabled(?*anyopaque, bool) void;
-    extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
-    extern fn dx_draw(?*anyopaque, u32, u32) void;
-    extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32) void;
+    pub extern fn dx_create(?*anyopaque, u32, u32) ?*anyopaque;
+    pub extern fn dx_destroy(?*anyopaque) void;
+    pub extern fn dx_resize(?*anyopaque, u32, u32) void;
+    pub extern fn dx_present(?*anyopaque, bool) void;
+    pub extern fn dx_clear(?*anyopaque, f32, f32, f32, f32) void;
+    pub extern fn dx_set_viewport(?*anyopaque, u32, u32) void;
+    pub extern fn dx_bind_backbuffer(?*anyopaque) void;
+    pub extern fn dx_set_blend_enabled(?*anyopaque, bool) void;
+    pub extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
+    pub extern fn dx_draw(?*anyopaque, u32, u32) void;
+    pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32) void;
 
-    extern fn dx_create_buffer(?*anyopaque, u32, u32, ?*const anyopaque) ?*anyopaque;
-    extern fn dx_destroy_buffer(?*anyopaque) void;
-    extern fn dx_update_buffer(?*anyopaque, ?*anyopaque, ?*const anyopaque, u32) void;
-    extern fn dx_bind_vertex_buffer(?*anyopaque, ?*anyopaque, u32, u32) void;
-    extern fn dx_bind_constant_buffer(?*anyopaque, ?*anyopaque, u32, bool, bool) void;
-    extern fn dx_bind_srv_buffer(?*anyopaque, ?*anyopaque, u32, u32) void;
+    pub const CompiledShader = extern struct { bytecode: ?*anyopaque, size: u32 };
+    pub extern fn dx_compile_shader(?[*]const u8, u32, [*:0]const u8, [*:0]const u8) CompiledShader;
+    pub extern fn dx_free_compiled_shader(CompiledShader) void;
 
-    extern fn dx_create_texture(?*anyopaque, u32, u32, u32, ?*const anyopaque) ?*anyopaque;
-    extern fn dx_destroy_texture(?*anyopaque) void;
-    extern fn dx_update_texture_region(?*anyopaque, ?*anyopaque, u32, u32, u32, u32, ?*const anyopaque) void;
-    extern fn dx_bind_texture(?*anyopaque, ?*anyopaque, u32) void;
+    pub extern fn dx_create_buffer(?*anyopaque, u32, u32, ?*const anyopaque) ?*anyopaque;
+    pub extern fn dx_destroy_buffer(?*anyopaque) void;
+    pub extern fn dx_update_buffer(?*anyopaque, ?*anyopaque, ?*const anyopaque, u32) void;
+    pub extern fn dx_bind_vertex_buffer(?*anyopaque, ?*anyopaque, u32, u32) void;
+    pub extern fn dx_bind_constant_buffer(?*anyopaque, ?*anyopaque, u32, bool, bool) void;
+    pub extern fn dx_bind_srv_buffer(?*anyopaque, ?*anyopaque, u32, u32) void;
 
-    extern fn dx_create_sampler(?*anyopaque, u32, u32) ?*anyopaque;
-    extern fn dx_destroy_sampler(?*anyopaque) void;
-    extern fn dx_bind_sampler(?*anyopaque, ?*anyopaque, u32) void;
+    pub extern fn dx_create_texture(?*anyopaque, u32, u32, u32, ?*const anyopaque) ?*anyopaque;
+    pub extern fn dx_destroy_texture(?*anyopaque) void;
+    pub extern fn dx_update_texture_region(?*anyopaque, ?*anyopaque, u32, u32, u32, u32, ?*const anyopaque) void;
+    pub extern fn dx_bind_texture(?*anyopaque, ?*anyopaque, u32) void;
 
-    extern fn dx_create_render_target(?*anyopaque, u32, u32, u32) ?*anyopaque;
-    extern fn dx_destroy_render_target(?*anyopaque) void;
-    extern fn dx_bind_render_target(?*anyopaque, ?*anyopaque) void;
+    pub extern fn dx_create_sampler(?*anyopaque, u32, u32) ?*anyopaque;
+    pub extern fn dx_destroy_sampler(?*anyopaque) void;
+    pub extern fn dx_bind_sampler(?*anyopaque, ?*anyopaque, u32) void;
+
+    pub extern fn dx_create_pipeline(?*anyopaque, ?*anyopaque, u32, ?*anyopaque, u32, ?*anyopaque, u32) ?*anyopaque;
+    pub extern fn dx_destroy_pipeline(?*anyopaque) void;
+    pub extern fn dx_bind_pipeline(?*anyopaque, ?*anyopaque) void;
+
+    pub extern fn dx_create_render_target(?*anyopaque, u32, u32, u32) ?*anyopaque;
+    pub extern fn dx_destroy_render_target(?*anyopaque) void;
+    pub extern fn dx_bind_render_target(?*anyopaque, ?*anyopaque) void;
 };
 
 alloc: std.mem.Allocator,

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -27,6 +27,10 @@ pub const custom_shader_target: shadertoy.Target = .glsl;
 pub const custom_shader_y_is_down = true;
 pub const swap_chain_count = 2;
 
+/// Use a native Windows render loop instead of xev.
+/// xev's IOCP event loop stalls after D3D11 device creation.
+pub const native_render_loop = true;
+
 const log = std.log.scoped(.directx);
 
 /// Global device handle, accessible by Buffer/Texture/etc.
@@ -101,7 +105,6 @@ pub fn deinit(self: *DirectX) void {
 }
 
 pub fn surfaceInit(surface: *apprt.Surface) !void {
-    // Store HWND for device creation in threadEnter (must be on renderer thread).
     if (comptime builtin.os.tag != .windows) return;
     stored_hwnd = @ptrCast(surface.platform.windows.hwnd);
 }
@@ -113,8 +116,6 @@ pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void 
 
 pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
     _ = surface;
-    // Create D3D11 device on renderer thread. The immediate context
-    // must only be used from this thread.
     const hwnd = stored_hwnd orelse return;
     const w32 = struct {
         const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
@@ -122,12 +123,10 @@ pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
     };
     var rect: w32.RECT = undefined;
     _ = w32.GetClientRect(hwnd, &rect);
-    const w: u32 = @intCast(rect.right - rect.left);
-    const h: u32 = @intCast(rect.bottom - rect.top);
+    const w: u32 = @intCast(@max(rect.right - rect.left, 1));
+    const h: u32 = @intCast(@max(rect.bottom - rect.top, 1));
 
-    const dev = dx.dx_create(hwnd, w, h) orelse {
-        return error.DirectXFailed;
-    };
+    const dev = dx.dx_create(hwnd, w, h) orelse return;
     const self_mut: *DirectX = @constCast(self);
     self_mut.device = dev;
     current_device = dev;
@@ -154,6 +153,7 @@ pub fn drawFrameStart(self: *DirectX) void {
     dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
 }
 
+
 pub fn drawFrameEnd(self: *DirectX) void {
     _ = self;
     const dev = current_device orelse return;
@@ -163,26 +163,10 @@ pub fn drawFrameEnd(self: *DirectX) void {
 pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
     _ = self;
     const dev = current_device orelse return .{ .width = 960, .height = 640 };
-    const hwnd = stored_hwnd orelse return .{ .width = 960, .height = 640 };
-
-    // Get actual window client size
-    const w32 = struct {
-        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
-        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
-    };
-    var rect: w32.RECT = undefined;
-    _ = w32.GetClientRect(hwnd, &rect);
-    const w: u32 = @intCast(@max(rect.right - rect.left, 1));
-    const h: u32 = @intCast(@max(rect.bottom - rect.top, 1));
-
-    // Resize swap chain if window size changed
-    var bbw: u32 = 0;
-    var bbh: u32 = 0;
-    dx.dx_get_backbuffer_size(dev, &bbw, &bbh);
-    if (bbw != w or bbh != h) {
-        dx.dx_resize(dev, w, h);
-    }
-
+    var w: u32 = 0;
+    var h: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &w, &h);
+    if (w == 0 or h == 0) return .{ .width = 960, .height = 640 };
     return .{ .width = w, .height = h };
 }
 
@@ -217,7 +201,12 @@ pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
     dx.dx_bind_backbuffer(dev);
     dx.dx_set_blend_enabled(dev, false);
     dx.dx_ensure_default_sampler(dev);
-    dx.dx_clear(dev, 1.0, 0.0, 0.0, 1.0); // RED = build applied
+    dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
+    // Log that beginFrame ran (means needs_redraw=true)
+    const k32 = struct {
+        extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
+    };
+    k32.OutputDebugStringA("beginFrame: needs_redraw=true\n");
     return Frame.begin(renderer, target);
 }
 
@@ -227,8 +216,6 @@ pub fn present(self: *DirectX, target: Target) !void {
 
 pub fn presentLastTarget(self: *DirectX) !void {
     _ = self;
-    // No-op: DWM keeps showing the last presented frame.
-    // With DXGI_SWAP_EFFECT_DISCARD, we can't re-present stale content.
 }
 
 pub fn initAtlasTexture(self: *const DirectX, atlas: anytype) !Texture {

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -44,6 +44,7 @@ pub const dx = struct {
     pub extern fn dx_set_viewport(?*anyopaque, u32, u32) void;
     pub extern fn dx_bind_backbuffer(?*anyopaque) void;
     pub extern fn dx_set_blend_enabled(?*anyopaque, bool) void;
+    pub extern fn dx_clear_shader_resources(?*anyopaque) void;
     pub extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
     pub extern fn dx_draw(?*anyopaque, u32, u32, u32) void;
     pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32, u32) void;
@@ -70,6 +71,8 @@ pub const dx = struct {
 
     pub extern fn dx_create_pipeline(?*anyopaque, ?*anyopaque, u32, ?*anyopaque, u32, ?*anyopaque, u32) ?*anyopaque;
     pub extern fn dx_create_cell_text_pipeline(?*anyopaque, ?*anyopaque, u32, ?*anyopaque, u32) ?*anyopaque;
+    pub extern fn dx_create_bg_image_pipeline(?*anyopaque, ?*anyopaque, u32, ?*anyopaque, u32) ?*anyopaque;
+    pub extern fn dx_create_image_pipeline(?*anyopaque, ?*anyopaque, u32, ?*anyopaque, u32) ?*anyopaque;
     pub extern fn dx_destroy_pipeline(?*anyopaque) void;
     pub extern fn dx_bind_pipeline(?*anyopaque, ?*anyopaque) void;
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -32,7 +32,7 @@ const log = std.log.scoped(.directx);
 /// Global device handle, accessible by Buffer/Texture/etc.
 pub var current_device: ?*anyopaque = null;
 /// HWND stored from surfaceInit for device creation in threadEnter.
-var stored_hwnd: ?*anyopaque = null;
+pub var stored_hwnd: ?*anyopaque = null;
 
 // C API from d3d11_impl.c
 pub const dx = struct {
@@ -49,7 +49,6 @@ pub const dx = struct {
     pub extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
     pub extern fn dx_draw(?*anyopaque, u32, u32, u32) void;
     pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32, u32) void;
-    pub extern fn dx_test_draw(?*anyopaque) void;
 
     pub const CompiledShader = extern struct { bytecode: ?*anyopaque, size: u32 };
     pub extern fn dx_compile_shader(?[*]const u8, u32, [*:0]const u8, [*:0]const u8) CompiledShader;
@@ -87,7 +86,6 @@ alloc: std.mem.Allocator,
 blending: configpkg.Config.AlphaBlending,
 last_target: ?Target = null,
 device: ?*anyopaque = null,
-frame_rendered: bool = false,
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
     log.info("initializing DirectX 11 renderer", .{});
@@ -144,10 +142,8 @@ pub fn displayRealized(self: *const DirectX) void {
 }
 
 pub fn drawFrameStart(self: *DirectX) void {
-    self.frame_rendered = false;
-    // Use global device - self.device may not persist due to value copy semantics
+    _ = self;
     const dev = current_device orelse return;
-    self.device = dev;
     var w: u32 = 0;
     var h: u32 = 0;
     dx.dx_get_backbuffer_size(dev, &w, &h);
@@ -159,17 +155,34 @@ pub fn drawFrameStart(self: *DirectX) void {
 }
 
 pub fn drawFrameEnd(self: *DirectX) void {
+    _ = self;
     const dev = current_device orelse return;
-    self.frame_rendered = true;
     dx.dx_present(dev, false);
 }
 
 pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
     _ = self;
     const dev = current_device orelse return .{ .width = 960, .height = 640 };
-    var w: u32 = 0;
-    var h: u32 = 0;
-    dx.dx_get_backbuffer_size(dev, &w, &h);
+    const hwnd = stored_hwnd orelse return .{ .width = 960, .height = 640 };
+
+    // Get actual window client size
+    const w32 = struct {
+        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
+        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
+    };
+    var rect: w32.RECT = undefined;
+    _ = w32.GetClientRect(hwnd, &rect);
+    const w: u32 = @intCast(@max(rect.right - rect.left, 1));
+    const h: u32 = @intCast(@max(rect.bottom - rect.top, 1));
+
+    // Resize swap chain if window size changed
+    var bbw: u32 = 0;
+    var bbh: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &bbw, &bbh);
+    if (bbw != w or bbh != h) {
+        dx.dx_resize(dev, w, h);
+    }
+
     return .{ .width = w, .height = h };
 }
 
@@ -194,6 +207,17 @@ pub fn initTarget(self: *const DirectX, width: usize, height: usize) !Target {
 
 pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
     _ = self;
+    // beginFrame is only called when needs_redraw=true.
+    // Clear and set up the backbuffer for this frame's render passes.
+    const dev = current_device orelse return Frame.begin(renderer, target);
+    var w: u32 = 0;
+    var h: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &w, &h);
+    dx.dx_set_viewport(dev, w, h);
+    dx.dx_bind_backbuffer(dev);
+    dx.dx_set_blend_enabled(dev, false);
+    dx.dx_ensure_default_sampler(dev);
+    dx.dx_clear(dev, 1.0, 0.0, 0.0, 1.0); // RED = build applied
     return Frame.begin(renderer, target);
 }
 
@@ -202,10 +226,9 @@ pub fn present(self: *DirectX, target: Target) !void {
 }
 
 pub fn presentLastTarget(self: *DirectX) !void {
-    // With DXGI_SWAP_EFFECT_DISCARD, backbuffer content is undefined after Present.
-    // We can't re-present the last frame. Just present what's there.
-    // The real fix is to always redraw, but for now this avoids a second Present call.
     _ = self;
+    // No-op: DWM keeps showing the last presented frame.
+    // With DXGI_SWAP_EFFECT_DISCARD, we can't re-present stale content.
 }
 
 pub fn initAtlasTexture(self: *const DirectX, atlas: anytype) !Texture {

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -232,8 +232,6 @@ pub fn initTarget(self: *const DirectX, width: usize, height: usize) !Target {
 
 pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
     _ = self;
-    // beginFrame is only called when needs_redraw=true.
-    // Clear and set up the backbuffer for this frame's render passes.
     const dev = current_device orelse return Frame.begin(renderer, target);
     var w: u32 = 0;
     var h: u32 = 0;
@@ -243,11 +241,6 @@ pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
     dx.dx_set_blend_enabled(dev, false);
     dx.dx_ensure_default_sampler(dev);
     dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
-    // Log that beginFrame ran (means needs_redraw=true)
-    const k32 = struct {
-        extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
-    };
-    k32.OutputDebugStringA("beginFrame: needs_redraw=true\n");
     return Frame.begin(renderer, target);
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -177,7 +177,6 @@ pub fn drawFrameStart(self: *DirectX) void {
     dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
 }
 
-
 pub fn drawFrameEnd(self: *DirectX) void {
     _ = self;
     const dev = current_device orelse return;
@@ -232,15 +231,6 @@ pub fn initTarget(self: *const DirectX, width: usize, height: usize) !Target {
 
 pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
     _ = self;
-    const dev = current_device orelse return Frame.begin(renderer, target);
-    var w: u32 = 0;
-    var h: u32 = 0;
-    dx.dx_get_backbuffer_size(dev, &w, &h);
-    dx.dx_set_viewport(dev, w, h);
-    dx.dx_bind_backbuffer(dev);
-    dx.dx_set_blend_enabled(dev, false);
-    dx.dx_ensure_default_sampler(dev);
-    dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
     return Frame.begin(renderer, target);
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -161,8 +161,9 @@ pub fn initShaders(
     alloc: Allocator,
     custom_shaders: []const [:0]const u8,
 ) !shaders.Shaders {
-    _ = self;
-    return try shaders.Shaders.init(alloc, custom_shaders);
+    var s = try shaders.Shaders.init(alloc, custom_shaders);
+    s.compileAll(self.device);
+    return s;
 }
 
 pub fn initTarget(self: *const DirectX, width: usize, height: usize) !Target {

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -29,8 +29,18 @@ pub const swap_chain_count = 2;
 
 const log = std.log.scoped(.directx);
 
-/// Thread-local device handle, accessible by Buffer/Texture/etc.
-pub threadlocal var current_device: ?*anyopaque = null;
+fn dbgLog(msg: [*:0]const u8) void {
+    if (comptime builtin.os.tag == .windows) {
+        const k32 = struct {
+            extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
+        };
+        k32.OutputDebugStringA(msg);
+    }
+}
+
+/// Global device handle, accessible by Buffer/Texture/etc.
+/// Set in surfaceInit, used across threads.
+pub var current_device: ?*anyopaque = null;
 
 // C API from d3d11_impl.c
 pub const dx = struct {
@@ -89,13 +99,33 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
 }
 
 pub fn deinit(self: *DirectX) void {
+    dbgLog("DirectX.deinit called\n");
     if (self.device) |dev| dx.dx_destroy(dev);
     self.* = undefined;
 }
 
 pub fn surfaceInit(surface: *apprt.Surface) !void {
-    _ = surface;
-    log.info("DirectX surfaceInit (device created in threadEnter)", .{});
+    // Create D3D11 device here (before initShaders is called).
+    // surfaceInit runs on the surface creation thread, initShaders follows.
+    if (comptime builtin.os.tag != .windows) return;
+    const platform = surface.platform.windows;
+    const hwnd: ?*anyopaque = @ptrCast(platform.hwnd);
+
+    const w32 = struct {
+        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
+        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
+    };
+    var rect: w32.RECT = undefined;
+    _ = w32.GetClientRect(hwnd, &rect);
+    const w: u32 = @intCast(rect.right - rect.left);
+    const h: u32 = @intCast(rect.bottom - rect.top);
+
+    const dev = dx.dx_create(hwnd, w, h) orelse {
+        dbgLog("DirectX.surfaceInit: FAILED to create device\n");
+        return error.DirectXFailed;
+    };
+    current_device = dev;
+    dbgLog("DirectX.surfaceInit: device created\n");
 }
 
 pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
@@ -104,29 +134,12 @@ pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void 
 }
 
 pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
-    // DirectX is Windows-only
-    if (comptime builtin.os.tag != .windows) return;
-
-    const platform = surface.platform.windows;
-    const hwnd: ?*anyopaque = @ptrCast(platform.hwnd);
-
-    const win32 = struct {
-        const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
-        extern "user32" fn GetClientRect(?*anyopaque, *RECT) callconv(.winapi) i32;
-    };
-    var rect: win32.RECT = undefined;
-    _ = win32.GetClientRect(hwnd, &rect);
-    const w: u32 = @intCast(rect.right - rect.left);
-    const h: u32 = @intCast(rect.bottom - rect.top);
-
-    const dev = dx.dx_create(hwnd, w, h) orelse {
-        log.err("failed to create D3D11 device", .{});
-        return error.DirectXFailed;
-    };
+    _ = surface;
+    // Device was created in surfaceInit (which runs before initShaders).
+    // threadEnter runs on the renderer thread - just store the device reference.
     const self_mut: *DirectX = @constCast(self);
-    self_mut.device = dev;
-    current_device = dev;
-    log.info("D3D11 device created ({d}x{d})", .{ w, h });
+    self_mut.device = current_device;
+    dbgLog("DirectX.threadEnter: using device from surfaceInit\n");
 }
 
 pub fn threadExit(self: *const DirectX) void {
@@ -168,8 +181,13 @@ pub fn initShaders(
     alloc: Allocator,
     custom_shaders: []const [:0]const u8,
 ) !shaders.Shaders {
+    // Use threadlocal device (set in surfaceInit on same thread)
+    const dev = current_device orelse self.device;
+    dbgLog(if (dev != null) "DirectX.initShaders: device OK\n" else "DirectX.initShaders: device NULL!\n");
     var s = try shaders.Shaders.init(alloc, custom_shaders);
-    s.compileAll(self.device);
+    if (dev != null) {
+        s.compileAll(dev);
+    }
     return s;
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -29,15 +29,6 @@ pub const swap_chain_count = 2;
 
 const log = std.log.scoped(.directx);
 
-pub fn dbgLog(msg: [*:0]const u8) void {
-    if (comptime builtin.os.tag == .windows) {
-        const k32 = struct {
-            extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
-        };
-        k32.OutputDebugStringA(msg);
-    }
-}
-
 /// Global device handle, accessible by Buffer/Texture/etc.
 pub var current_device: ?*anyopaque = null;
 /// HWND stored from surfaceInit for device creation in threadEnter.
@@ -54,8 +45,8 @@ pub const dx = struct {
     pub extern fn dx_bind_backbuffer(?*anyopaque) void;
     pub extern fn dx_set_blend_enabled(?*anyopaque, bool) void;
     pub extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
-    pub extern fn dx_draw(?*anyopaque, u32, u32) void;
-    pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32) void;
+    pub extern fn dx_draw(?*anyopaque, u32, u32, u32) void;
+    pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32, u32) void;
 
     pub const CompiledShader = extern struct { bytecode: ?*anyopaque, size: u32 };
     pub extern fn dx_compile_shader(?[*]const u8, u32, [*:0]const u8, [*:0]const u8) CompiledShader;
@@ -100,7 +91,6 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
 }
 
 pub fn deinit(self: *DirectX) void {
-    dbgLog("DirectX.deinit called\n");
     if (self.device) |dev| dx.dx_destroy(dev);
     self.* = undefined;
 }
@@ -109,7 +99,6 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
     // Store HWND for device creation in threadEnter (must be on renderer thread).
     if (comptime builtin.os.tag != .windows) return;
     stored_hwnd = @ptrCast(surface.platform.windows.hwnd);
-    dbgLog("DirectX.surfaceInit: HWND stored\n");
 }
 
 pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
@@ -132,13 +121,11 @@ pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
     const h: u32 = @intCast(rect.bottom - rect.top);
 
     const dev = dx.dx_create(hwnd, w, h) orelse {
-        dbgLog("DirectX.threadEnter: FAILED to create device\n");
         return error.DirectXFailed;
     };
     const self_mut: *DirectX = @constCast(self);
     self_mut.device = dev;
     current_device = dev;
-    dbgLog("DirectX.threadEnter: device created on renderer thread\n");
 }
 
 pub fn threadExit(self: *const DirectX) void {
@@ -182,7 +169,6 @@ pub fn initShaders(
     alloc: Allocator,
     custom_shaders: []const [:0]const u8,
 ) !shaders.Shaders {
-    dbgLog("DirectX.initShaders: compiling HLSL bytecode (no device)\n");
     var s = try shaders.Shaders.init(alloc, custom_shaders);
     s.storeSource();
     // Device objects created later in threadEnter via drawFrameStart

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -45,6 +45,7 @@ pub const dx = struct {
     pub extern fn dx_bind_backbuffer(?*anyopaque) void;
     pub extern fn dx_set_blend_enabled(?*anyopaque, bool) void;
     pub extern fn dx_clear_shader_resources(?*anyopaque) void;
+    pub extern fn dx_ensure_default_sampler(?*anyopaque) void;
     pub extern fn dx_get_backbuffer_size(?*anyopaque, *u32, *u32) void;
     pub extern fn dx_draw(?*anyopaque, u32, u32, u32) void;
     pub extern fn dx_draw_instanced(?*anyopaque, u32, u32, u32, u32, u32) void;
@@ -148,6 +149,7 @@ pub fn drawFrameStart(self: *DirectX) void {
         dx.dx_set_viewport(dev, w, h);
         dx.dx_bind_backbuffer(dev);
         dx.dx_set_blend_enabled(dev, false);
+        dx.dx_ensure_default_sampler(dev);
         dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
     }
 }
@@ -229,7 +231,8 @@ pub inline fn uniformBufferOptions(self: DirectX) bufferpkg.Options {
 
 pub inline fn fgBufferOptions(self: DirectX) bufferpkg.Options {
     _ = self;
-    return .{ .target = .shader_storage, .usage = .dynamic_draw };
+    // In D3D11, foreground cell data is used as vertex buffer (per-instance)
+    return .{ .target = .array, .usage = .dynamic_draw };
 }
 
 pub inline fn bgBufferOptions(self: DirectX) bufferpkg.Options {

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -39,8 +39,9 @@ fn dbgLog(msg: [*:0]const u8) void {
 }
 
 /// Global device handle, accessible by Buffer/Texture/etc.
-/// Set in surfaceInit, used across threads.
 pub var current_device: ?*anyopaque = null;
+/// Global shaders pointer for deferred device object creation.
+pub var pending_shader_init: ?*shaders.Shaders = null;
 
 // C API from d3d11_impl.c
 pub const dx = struct {
@@ -105,8 +106,8 @@ pub fn deinit(self: *DirectX) void {
 }
 
 pub fn surfaceInit(surface: *apprt.Surface) !void {
-    // Create D3D11 device here (before initShaders is called).
-    // surfaceInit runs on the surface creation thread, initShaders follows.
+    // Create D3D11 device here. ID3D11Device is thread-safe for object creation
+    // (CreateVertexShader etc). Only ID3D11DeviceContext is single-threaded.
     if (comptime builtin.os.tag != .windows) return;
     const platform = surface.platform.windows;
     const hwnd: ?*anyopaque = @ptrCast(platform.hwnd);
@@ -135,11 +136,11 @@ pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void 
 
 pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
     _ = surface;
-    // Device was created in surfaceInit (which runs before initShaders).
-    // threadEnter runs on the renderer thread - just store the device reference.
+    // Device was created in surfaceInit. Store reference for drawing.
+    // ID3D11DeviceContext calls must happen on this (renderer) thread.
     const self_mut: *DirectX = @constCast(self);
     self_mut.device = current_device;
-    dbgLog("DirectX.threadEnter: using device from surfaceInit\n");
+    dbgLog("DirectX.threadEnter: renderer thread ready\n");
 }
 
 pub fn threadExit(self: *const DirectX) void {
@@ -157,6 +158,8 @@ pub fn drawFrameStart(self: *DirectX) void {
         dx.dx_get_backbuffer_size(dev, &w, &h);
         dx.dx_set_viewport(dev, w, h);
         dx.dx_bind_backbuffer(dev);
+        // Red clear = debug marker (shader should overwrite with bg color)
+        dx.dx_clear(dev, 1.0, 0.0, 0.0, 1.0);
     }
 }
 
@@ -177,17 +180,15 @@ pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
 }
 
 pub fn initShaders(
-    self: *const DirectX,
+    _: *const DirectX,
     alloc: Allocator,
     custom_shaders: []const [:0]const u8,
 ) !shaders.Shaders {
-    // Use threadlocal device (set in surfaceInit on same thread)
-    const dev = current_device orelse self.device;
-    dbgLog(if (dev != null) "DirectX.initShaders: device OK\n" else "DirectX.initShaders: device NULL!\n");
+    const dev = current_device;
+    dbgLog(if (dev != null) "DirectX.initShaders: device OK, compiling\n" else "DirectX.initShaders: no device!\n");
     var s = try shaders.Shaders.init(alloc, custom_shaders);
-    if (dev != null) {
-        s.compileAll(dev);
-    }
+    s.compileBytecode();
+    s.createDeviceObjects(dev);
     return s;
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -242,7 +242,10 @@ fn threadMain_(self: *Thread) !void {
         break :blk @hasDecl(RendererType, "API") and @hasDecl(RendererType.API, "native_render_loop") and RendererType.API.native_render_loop;
     };
 
-    if (!use_native_loop) {
+    if (use_native_loop) {
+        const RendererType = rendererpkg.Renderer;
+        RendererType.API.stop_requested.store(false, .seq_cst);
+    } else {
         self.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
         self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
         self.draw_now.wait(&self.loop, &self.draw_now_c, Thread, self, drawNowCallback);
@@ -267,13 +270,14 @@ fn threadMain_(self: *Thread) !void {
         // Native Windows render loop for DirectX.
         // xev's IOCP event loop is incompatible with D3D11 device context,
         // so we use a simple poll loop similar to Windows Terminal's RenderThread.
+        const RendererType = rendererpkg.Renderer;
         const w32 = struct {
             extern "kernel32" fn Sleep(u32) callconv(.winapi) void;
             extern "kernel32" fn GetTickCount64() callconv(.winapi) u64;
         };
         var last_blink: u64 = w32.GetTickCount64();
 
-        while (true) {
+        while (!RendererType.API.stop_requested.load(.monotonic)) {
             self.drainMailbox() catch {};
 
             self.renderer.updateFrame(
@@ -289,7 +293,8 @@ fn threadMain_(self: *Thread) !void {
 
             self.renderer.drawFrame(false) catch {};
 
-            w32.Sleep(8);
+            // Adaptive sleep: 8ms (~120fps) when focused, 32ms (~30fps) when not
+            w32.Sleep(if (self.flags.focused) 8 else 32);
         }
     } else {
         _ = try self.loop.run(.until_done);

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -270,14 +270,27 @@ fn threadMain_(self: *Thread) !void {
         // Native Windows render loop for DirectX.
         // xev's IOCP event loop is incompatible with D3D11 device context,
         // so we use a simple poll loop similar to Windows Terminal's RenderThread.
+        //
+        // Register stop handler: when Surface calls stop.notify(), run the
+        // xev loop briefly to process it and set our atomic flag.
         const RendererType = rendererpkg.Renderer;
+        RendererType.API.stop_requested.store(false, .monotonic);
+        self.stop.wait(&self.loop, &self.stop_c, Thread, self, nativeStopCallback);
+
         const w32 = struct {
             extern "kernel32" fn Sleep(u32) callconv(.winapi) void;
             extern "kernel32" fn GetTickCount64() callconv(.winapi) u64;
+            extern "winmm" fn timeBeginPeriod(u32) callconv(.winapi) u32;
+            extern "winmm" fn timeEndPeriod(u32) callconv(.winapi) u32;
         };
+        // Set timer resolution to 1ms for accurate Sleep
+        _ = w32.timeBeginPeriod(1);
+        defer _ = w32.timeEndPeriod(1);
         var last_blink: u64 = w32.GetTickCount64();
 
         while (!RendererType.API.stop_requested.load(.monotonic)) {
+            // Poll xev for stop signal (non-blocking)
+            _ = self.loop.run(.no_wait) catch {};
             self.drainMailbox() catch {};
 
             self.renderer.updateFrame(
@@ -293,8 +306,8 @@ fn threadMain_(self: *Thread) !void {
 
             self.renderer.drawFrame(false) catch {};
 
-            // Adaptive sleep: 8ms (~120fps) when focused, 32ms (~30fps) when not
-            w32.Sleep(if (self.flags.focused) 8 else 32);
+            // Adaptive sleep: 4ms (~240fps) when focused, 16ms (~60fps) when not
+            w32.Sleep(if (self.flags.focused) 4 else 16);
         }
     } else {
         _ = try self.loop.run(.until_done);
@@ -734,6 +747,22 @@ fn stopCallback(
 ) xev.CallbackAction {
     _ = r catch unreachable;
     self_.?.loop.stop();
+    return .disarm;
+}
+
+/// Stop callback for native render loop. Sets the atomic flag
+/// so the poll loop exits.
+fn nativeStopCallback(
+    _: ?*Thread,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Async.WaitError!void,
+) xev.CallbackAction {
+    _ = r catch return .disarm;
+    const RendererType = rendererpkg.Renderer;
+    if (@hasDecl(RendererType, "API") and @hasDecl(RendererType.API, "stop_requested")) {
+        RendererType.API.stop_requested.store(true, .monotonic);
+    }
     return .disarm;
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -235,31 +235,65 @@ fn threadMain_(self: *Thread) !void {
     try self.renderer.threadEnter(self.surface);
     defer self.renderer.threadExit();
 
-    // Start the async handlers
-    self.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
-    self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
-    self.draw_now.wait(&self.loop, &self.draw_now_c, Thread, self, drawNowCallback);
+    // DirectX: xev's IOCP loop stalls after D3D11 device creation.
+    // Use a simple native render loop instead.
+    const use_native_loop = comptime blk: {
+        const RendererType = rendererpkg.Renderer;
+        break :blk @hasDecl(RendererType, "API") and @hasDecl(RendererType.API, "native_render_loop") and RendererType.API.native_render_loop;
+    };
 
-    // Send an initial wakeup message so that we render right away.
-    try self.wakeup.notify();
+    if (!use_native_loop) {
+        self.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
+        self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
+        self.draw_now.wait(&self.loop, &self.draw_now_c, Thread, self, drawNowCallback);
+        try self.wakeup.notify();
 
-    // Start blinking the cursor.
-    self.cursor_h.run(
-        &self.loop,
-        &self.cursor_c,
-        cursorBlinkInterval(),
-        Thread,
-        self,
-        cursorTimerCallback,
-    );
-
-    // Start the draw timer
-    self.syncDrawTimer();
+        self.cursor_h.run(
+            &self.loop,
+            &self.cursor_c,
+            cursorBlinkInterval(),
+            Thread,
+            self,
+            cursorTimerCallback,
+        );
+        self.syncDrawTimer();
+    }
 
     // Run
     log.debug("starting renderer thread", .{});
     defer log.debug("starting renderer thread shutdown", .{});
-    _ = try self.loop.run(.until_done);
+
+    if (use_native_loop) {
+        // Native Windows render loop for DirectX.
+        // xev's IOCP event loop is incompatible with D3D11 device context,
+        // so we use a simple poll loop similar to Windows Terminal's RenderThread.
+        const w32 = struct {
+            extern "kernel32" fn Sleep(u32) callconv(.winapi) void;
+            extern "kernel32" fn GetTickCount64() callconv(.winapi) u64;
+        };
+        var last_blink: u64 = w32.GetTickCount64();
+
+        while (true) {
+            self.drainMailbox() catch {};
+
+            self.renderer.updateFrame(
+                self.state,
+                self.flags.cursor_blink_visible,
+            ) catch {};
+
+            const now = w32.GetTickCount64();
+            if (now - last_blink >= cursorBlinkInterval()) {
+                self.flags.cursor_blink_visible = !self.flags.cursor_blink_visible;
+                last_blink = now;
+            }
+
+            self.renderer.drawFrame(false) catch {};
+
+            w32.Sleep(8);
+        }
+    } else {
+        _ = try self.loop.run(.until_done);
+    }
 }
 
 fn setQosClass(self: *const Thread) void {

--- a/src/renderer/backend.zig
+++ b/src/renderer/backend.zig
@@ -6,6 +6,7 @@ pub const Backend = enum {
     opengl,
     metal,
     webgl,
+    directx,
 
     pub fn default(
         target: std.Target,

--- a/src/renderer/directx/Frame.zig
+++ b/src/renderer/directx/Frame.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const DirectX = @import("../DirectX.zig");
+const rendererpkg = @import("../../renderer.zig");
+const Renderer = rendererpkg.GenericRenderer(DirectX);
+const Target = @import("Target.zig");
+const RenderPass = @import("RenderPass.zig");
+
+const Self = @This();
+
+renderer: *Renderer,
+target: *Target,
+
+pub fn begin(renderer: *Renderer, target: *Target) !Self {
+    return .{
+        .renderer = renderer,
+        .target = target,
+    };
+}
+
+pub fn renderPass(self: *const Self, attachments: []const RenderPass.Options.Attachment) RenderPass {
+    _ = self;
+    return RenderPass.begin(.{ .attachments = attachments });
+}
+
+pub fn complete(self: *const Self, sync: bool) void {
+    _ = self;
+    _ = sync;
+    // TODO: Present swap chain
+}

--- a/src/renderer/directx/Frame.zig
+++ b/src/renderer/directx/Frame.zig
@@ -24,5 +24,9 @@ pub fn renderPass(self: *const Self, attachments: []const RenderPass.Options.Att
 
 pub fn complete(self: *const Self, sync: bool) void {
     _ = self;
-    _ = sync;
+    if (sync) {
+        // Flush the D3D11 command queue to ensure all commands are submitted.
+        // D3D11 doesn't have a direct equivalent of glFinish(), but
+        // the present call in drawFrameEnd handles synchronization.
+    }
 }

--- a/src/renderer/directx/Frame.zig
+++ b/src/renderer/directx/Frame.zig
@@ -23,10 +23,9 @@ pub fn renderPass(self: *const Self, attachments: []const RenderPass.Options.Att
 }
 
 pub fn complete(self: *const Self, sync: bool) void {
-    _ = self;
-    if (sync) {
-        // Flush the D3D11 command queue to ensure all commands are submitted.
-        // D3D11 doesn't have a direct equivalent of glFinish(), but
-        // the present call in drawFrameEnd handles synchronization.
-    }
+    _ = sync;
+    // Report frame health and release the swap chain semaphore.
+    // Without this, the semaphore exhausts after swap_chain_count frames
+    // and nextFrame() blocks forever.
+    self.renderer.frameCompleted(.healthy);
 }

--- a/src/renderer/directx/Frame.zig
+++ b/src/renderer/directx/Frame.zig
@@ -18,12 +18,11 @@ pub fn begin(renderer: *Renderer, target: *Target) !Self {
 }
 
 pub fn renderPass(self: *const Self, attachments: []const RenderPass.Options.Attachment) RenderPass {
-    _ = self;
-    return RenderPass.begin(.{ .attachments = attachments });
+    // Pass device handle from the renderer's API
+    return RenderPass.begin(self.renderer.api.device, .{ .attachments = attachments });
 }
 
 pub fn complete(self: *const Self, sync: bool) void {
     _ = self;
     _ = sync;
-    // TODO: Present swap chain
 }

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const DirectX = @import("../DirectX.zig");
+const dx = DirectX.dx;
 
 const Self = @This();
 
@@ -16,15 +18,38 @@ pub const Options = struct {
     };
 };
 
-// TODO: ID3D11VertexShader, ID3D11PixelShader, ID3D11InputLayout
+// D3D11 pipeline handle (DxPipeline*)
+handle: ?*anyopaque = null,
+blending_enabled: bool = true,
 
 pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     _ = VertexAttributes;
-    _ = opts;
-    // TODO: Compile HLSL shaders, create input layout
-    return .{};
+    // Pipeline creation is deferred to createOnDevice (needs DxDevice*)
+    return .{
+        .blending_enabled = opts.blending_enabled,
+    };
+}
+
+/// Create the actual D3D11 pipeline objects using the device.
+/// Called lazily when the device is available.
+pub fn createOnDevice(self: *Self, device: ?*anyopaque, vs_source: []const u8, ps_source: []const u8) !void {
+    if (self.handle != null) return; // Already created
+    if (device == null) return;
+
+    // Compile vertex shader
+    const vs = dx.dx_compile_shader(vs_source.ptr, @intCast(vs_source.len), "vs_main", "vs_5_0");
+    defer dx.dx_free_compiled_shader(vs);
+    if (vs.bytecode == null) return error.DirectXFailed;
+
+    // Compile pixel shader
+    const ps = dx.dx_compile_shader(ps_source.ptr, @intCast(ps_source.len), "ps_main", "ps_5_0");
+    defer dx.dx_free_compiled_shader(ps);
+    if (ps.bytecode == null) return error.DirectXFailed;
+
+    // Create pipeline (input layout created from VS reflection)
+    self.handle = dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
 }
 
 pub fn deinit(self: *const Self) void {
-    _ = self;
+    if (self.handle) |h| dx.dx_destroy_pipeline(h);
 }

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -18,38 +18,56 @@ pub const Options = struct {
     };
 };
 
-// D3D11 pipeline handle (DxPipeline*)
+// D3D11 pipeline handle
 handle: ?*anyopaque = null,
 blending_enabled: bool = true,
 
+// Compiled bytecode (stored until device is available)
+vs_bytecode: ?*anyopaque = null,
+vs_size: u32 = 0,
+ps_bytecode: ?*anyopaque = null,
+ps_size: u32 = 0,
+
 pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     _ = VertexAttributes;
-    // Pipeline creation is deferred to createOnDevice (needs DxDevice*)
     return .{
         .blending_enabled = opts.blending_enabled,
     };
 }
 
-/// Create the actual D3D11 pipeline objects using the device.
-/// Called lazily when the device is available.
-pub fn createOnDevice(self: *Self, device: ?*anyopaque, vs_source: []const u8, ps_source: []const u8) !void {
-    if (self.handle != null) return; // Already created
-    if (device == null) return;
+/// Compile HLSL source to bytecode. Does NOT need a D3D11 device.
+pub fn compileBytecode(self: *Self, vs_source: []const u8, ps_source: []const u8) void {
+    if (self.vs_bytecode != null) return; // Already compiled
 
-    // Compile vertex shader
     const vs = dx.dx_compile_shader(vs_source.ptr, @intCast(vs_source.len), "vs_main", "vs_5_0");
-    defer dx.dx_free_compiled_shader(vs);
-    if (vs.bytecode == null) return error.DirectXFailed;
+    if (vs.bytecode != null) {
+        self.vs_bytecode = vs.bytecode;
+        self.vs_size = vs.size;
+    }
 
-    // Compile pixel shader
     const ps = dx.dx_compile_shader(ps_source.ptr, @intCast(ps_source.len), "ps_main", "ps_5_0");
-    defer dx.dx_free_compiled_shader(ps);
-    if (ps.bytecode == null) return error.DirectXFailed;
+    if (ps.bytecode != null) {
+        self.ps_bytecode = ps.bytecode;
+        self.ps_size = ps.size;
+    }
+}
 
-    // Create pipeline (input layout created from VS reflection)
-    self.handle = dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
+/// Create D3D11 shader objects from bytecode. Needs device.
+pub fn createDeviceObjects(self: *Self, device: ?*anyopaque) void {
+    if (self.handle != null) return; // Already created
+    if (device == null or self.vs_bytecode == null or self.ps_bytecode == null) return;
+
+    self.handle = dx.dx_create_pipeline(device, self.vs_bytecode, self.vs_size, self.ps_bytecode, self.ps_size, null, 0);
+
+    // Free bytecode after creating device objects
+    dx.dx_free_compiled_shader(.{ .bytecode = self.vs_bytecode, .size = self.vs_size });
+    dx.dx_free_compiled_shader(.{ .bytecode = self.ps_bytecode, .size = self.ps_size });
+    self.vs_bytecode = null;
+    self.ps_bytecode = null;
 }
 
 pub fn deinit(self: *const Self) void {
     if (self.handle) |h| dx.dx_destroy_pipeline(h);
+    if (self.vs_bytecode) |b| dx.dx_free_compiled_shader(.{ .bytecode = b, .size = self.vs_size });
+    if (self.ps_bytecode) |b| dx.dx_free_compiled_shader(.{ .bytecode = b, .size = self.ps_size });
 }

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -21,7 +21,9 @@ pub const Options = struct {
 handle: ?*anyopaque = null,
 blending_enabled: bool = true,
 id: u8 = 0,
-has_cell_text_layout: bool = false,
+layout_type: LayoutType = .none,
+
+const LayoutType = enum { none, cell_text, bg_image, image };
 
 const MAX_PIPELINES = 16;
 
@@ -38,9 +40,15 @@ var next_id: u8 = 1;
 
 pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     const shaders_mod = @import("shaders.zig");
+    const lt: LayoutType = if (VertexAttributes) |VA| blk: {
+        if (VA == shaders_mod.CellText) break :blk .cell_text;
+        if (VA == shaders_mod.BgImage) break :blk .bg_image;
+        if (VA == shaders_mod.Image) break :blk .image;
+        break :blk .none;
+    } else .none;
     return .{
         .blending_enabled = opts.blending_enabled,
-        .has_cell_text_layout = (VertexAttributes != null and VertexAttributes.? == shaders_mod.CellText),
+        .layout_type = lt,
     };
 }
 
@@ -74,10 +82,12 @@ pub fn getHandle(self: Self, device: ?*anyopaque) ?*anyopaque {
 
     if (vs.bytecode == null or ps.bytecode == null) return null;
 
-    const h = if (self.has_cell_text_layout)
-        dx.dx_create_cell_text_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size)
-    else
-        dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
+    const h = switch (self.layout_type) {
+        .cell_text => dx.dx_create_cell_text_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size),
+        .bg_image => dx.dx_create_bg_image_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size),
+        .image => dx.dx_create_image_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size),
+        .none => dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0),
+    };
     handles[self.id] = h;
     return h;
 }

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+
+const Self = @This();
+
+pub const Options = struct {
+    vertex_fn: [:0]const u8,
+    fragment_fn: [:0]const u8,
+    vertex_attributes: ?type = null,
+    step_fn: StepFunction = .per_vertex,
+    blending_enabled: bool = true,
+
+    pub const StepFunction = enum {
+        constant,
+        per_vertex,
+        per_instance,
+    };
+};
+
+// TODO: ID3D11VertexShader, ID3D11PixelShader, ID3D11InputLayout
+
+pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
+    _ = VertexAttributes;
+    _ = opts;
+    // TODO: Compile HLSL shaders, create input layout
+    return .{};
+}
+
+pub fn deinit(self: *const Self) void {
+    _ = self;
+}

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -28,6 +28,13 @@ vs_size: u32 = 0,
 ps_bytecode: ?*anyopaque = null,
 ps_size: u32 = 0,
 
+// Cache index for lazy device object creation
+cache_id: u8 = 0,
+
+// Global pipeline cache (persists across value copies)
+var pipeline_cache: [16]?*anyopaque = .{null} ** 16;
+var next_cache_id: u8 = 1;
+
 pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     _ = VertexAttributes;
     return .{
@@ -37,7 +44,11 @@ pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
 
 /// Compile HLSL source to bytecode. Does NOT need a D3D11 device.
 pub fn compileBytecode(self: *Self, vs_source: []const u8, ps_source: []const u8) void {
-    if (self.vs_bytecode != null) return; // Already compiled
+    if (self.vs_bytecode != null) return;
+
+    // Assign cache ID for lazy device object lookup
+    self.cache_id = next_cache_id;
+    next_cache_id += 1;
 
     const vs = dx.dx_compile_shader(vs_source.ptr, @intCast(vs_source.len), "vs_main", "vs_5_0");
     if (vs.bytecode != null) {
@@ -53,13 +64,26 @@ pub fn compileBytecode(self: *Self, vs_source: []const u8, ps_source: []const u8
 }
 
 /// Create D3D11 shader objects from bytecode. Needs device.
+/// Uses global cache so value copies share the same handle.
 pub fn createDeviceObjects(self: *Self, device: ?*anyopaque) void {
-    if (self.handle != null) return; // Already created
+    // Check cache first (handles value copies sharing same pipeline)
+    if (self.cache_id > 0 and self.cache_id < pipeline_cache.len) {
+        if (pipeline_cache[self.cache_id]) |cached| {
+            self.handle = cached;
+            return;
+        }
+    }
+
     if (device == null or self.vs_bytecode == null or self.ps_bytecode == null) return;
 
     self.handle = dx.dx_create_pipeline(device, self.vs_bytecode, self.vs_size, self.ps_bytecode, self.ps_size, null, 0);
 
-    // Free bytecode after creating device objects
+    // Store in cache
+    if (self.cache_id > 0 and self.cache_id < pipeline_cache.len) {
+        pipeline_cache[self.cache_id] = self.handle;
+    }
+
+    // Free bytecode
     dx.dx_free_compiled_shader(.{ .bytecode = self.vs_bytecode, .size = self.vs_size });
     dx.dx_free_compiled_shader(.{ .bytecode = self.ps_bytecode, .size = self.ps_size });
     self.vs_bytecode = null;

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -21,6 +21,7 @@ pub const Options = struct {
 handle: ?*anyopaque = null,
 blending_enabled: bool = true,
 id: u8 = 0,
+has_cell_text_layout: bool = false,
 
 const MAX_PIPELINES = 16;
 
@@ -36,9 +37,10 @@ var handles: [MAX_PIPELINES]?*anyopaque = [_]?*anyopaque{null} ** MAX_PIPELINES;
 var next_id: u8 = 1;
 
 pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
-    _ = VertexAttributes;
+    const shaders_mod = @import("shaders.zig");
     return .{
         .blending_enabled = opts.blending_enabled,
+        .has_cell_text_layout = (VertexAttributes != null and VertexAttributes.? == shaders_mod.CellText),
     };
 }
 
@@ -72,7 +74,10 @@ pub fn getHandle(self: Self, device: ?*anyopaque) ?*anyopaque {
 
     if (vs.bytecode == null or ps.bytecode == null) return null;
 
-    const h = dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
+    const h = if (self.has_cell_text_layout)
+        dx.dx_create_cell_text_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size)
+    else
+        dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
     handles[self.id] = h;
     return h;
 }

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -18,22 +18,22 @@ pub const Options = struct {
     };
 };
 
-// D3D11 pipeline handle
 handle: ?*anyopaque = null,
 blending_enabled: bool = true,
+id: u8 = 0,
 
-// Compiled bytecode (stored until device is available)
-vs_bytecode: ?*anyopaque = null,
-vs_size: u32 = 0,
-ps_bytecode: ?*anyopaque = null,
-ps_size: u32 = 0,
+const MAX_PIPELINES = 16;
 
-// Cache index for lazy device object creation
-cache_id: u8 = 0,
+const SourceEntry = struct {
+    vs: ?[*]const u8 = null,
+    vs_len: u32 = 0,
+    ps: ?[*]const u8 = null,
+    ps_len: u32 = 0,
+};
 
-// Global pipeline cache (persists across value copies)
-var pipeline_cache: [16]?*anyopaque = .{null} ** 16;
-var next_cache_id: u8 = 1;
+var sources: [MAX_PIPELINES]SourceEntry = [_]SourceEntry{.{}} ** MAX_PIPELINES;
+var handles: [MAX_PIPELINES]?*anyopaque = [_]?*anyopaque{null} ** MAX_PIPELINES;
+var next_id: u8 = 1;
 
 pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     _ = VertexAttributes;
@@ -42,56 +42,45 @@ pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     };
 }
 
-/// Compile HLSL source to bytecode. Does NOT need a D3D11 device.
-pub fn compileBytecode(self: *Self, vs_source: []const u8, ps_source: []const u8) void {
-    if (self.vs_bytecode != null) return;
-
-    // Assign cache ID for lazy device object lookup
-    self.cache_id = next_cache_id;
-    next_cache_id += 1;
-
-    const vs = dx.dx_compile_shader(vs_source.ptr, @intCast(vs_source.len), "vs_main", "vs_5_0");
-    if (vs.bytecode != null) {
-        self.vs_bytecode = vs.bytecode;
-        self.vs_size = vs.size;
-    }
-
-    const ps = dx.dx_compile_shader(ps_source.ptr, @intCast(ps_source.len), "ps_main", "ps_5_0");
-    if (ps.bytecode != null) {
-        self.ps_bytecode = ps.bytecode;
-        self.ps_size = ps.size;
-    }
+/// Store HLSL source pointers (comptime data, always valid). No compilation yet.
+pub fn storeSource(self: *Self, vs_source: []const u8, ps_source: []const u8) void {
+    const id = next_id;
+    next_id += 1;
+    self.id = id;
+    sources[id] = .{
+        .vs = vs_source.ptr,
+        .vs_len = @intCast(vs_source.len),
+        .ps = ps_source.ptr,
+        .ps_len = @intCast(ps_source.len),
+    };
 }
 
-/// Create D3D11 shader objects from bytecode. Needs device.
-/// Uses global cache so value copies share the same handle.
-pub fn createDeviceObjects(self: *Self, device: ?*anyopaque) void {
-    // Check cache first (handles value copies sharing same pipeline)
-    if (self.cache_id > 0 and self.cache_id < pipeline_cache.len) {
-        if (pipeline_cache[self.cache_id]) |cached| {
-            self.handle = cached;
-            return;
-        }
+/// Get D3D11 pipeline handle. Compiles HLSL + creates shaders on first call (renderer thread).
+pub fn getHandle(self: Self, device: ?*anyopaque) ?*anyopaque {
+    if (self.id == 0 or self.id >= MAX_PIPELINES) {
+        DirectX.dbgLog("Pipeline.getHandle: bad id\n");
+        return null;
     }
+    if (handles[self.id]) |h| return h;
+    DirectX.dbgLog("Pipeline.getHandle: compiling on renderer thread\n");
+    if (device == null) return null;
 
-    if (device == null or self.vs_bytecode == null or self.ps_bytecode == null) return;
+    const src = &sources[self.id];
+    if (src.vs == null or src.ps == null) return null;
 
-    self.handle = dx.dx_create_pipeline(device, self.vs_bytecode, self.vs_size, self.ps_bytecode, self.ps_size, null, 0);
+    // Compile + create entirely on renderer thread
+    const vs = dx.dx_compile_shader(src.vs, src.vs_len, "vs_main", "vs_5_0");
+    const ps = dx.dx_compile_shader(src.ps, src.ps_len, "ps_main", "ps_5_0");
+    defer dx.dx_free_compiled_shader(vs);
+    defer dx.dx_free_compiled_shader(ps);
 
-    // Store in cache
-    if (self.cache_id > 0 and self.cache_id < pipeline_cache.len) {
-        pipeline_cache[self.cache_id] = self.handle;
-    }
+    if (vs.bytecode == null or ps.bytecode == null) return null;
 
-    // Free bytecode
-    dx.dx_free_compiled_shader(.{ .bytecode = self.vs_bytecode, .size = self.vs_size });
-    dx.dx_free_compiled_shader(.{ .bytecode = self.ps_bytecode, .size = self.ps_size });
-    self.vs_bytecode = null;
-    self.ps_bytecode = null;
+    const h = dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0);
+    handles[self.id] = h;
+    return h;
 }
 
 pub fn deinit(self: *const Self) void {
-    if (self.handle) |h| dx.dx_destroy_pipeline(h);
-    if (self.vs_bytecode) |b| dx.dx_free_compiled_shader(.{ .bytecode = b, .size = self.vs_size });
-    if (self.ps_bytecode) |b| dx.dx_free_compiled_shader(.{ .bytecode = b, .size = self.ps_size });
+    _ = self;
 }

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -57,12 +57,8 @@ pub fn storeSource(self: *Self, vs_source: []const u8, ps_source: []const u8) vo
 
 /// Get D3D11 pipeline handle. Compiles HLSL + creates shaders on first call (renderer thread).
 pub fn getHandle(self: Self, device: ?*anyopaque) ?*anyopaque {
-    if (self.id == 0 or self.id >= MAX_PIPELINES) {
-        DirectX.dbgLog("Pipeline.getHandle: bad id\n");
-        return null;
-    }
+    if (self.id == 0 or self.id >= MAX_PIPELINES) return null;
     if (handles[self.id]) |h| return h;
-    DirectX.dbgLog("Pipeline.getHandle: compiling on renderer thread\n");
     if (device == null) return null;
 
     const src = &sources[self.id];

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -67,15 +67,10 @@ pub fn begin(device: ?*anyopaque, opts: Options) Self {
 pub fn step(self: *Self, s: Step) void {
     const dev = self.device orelse return;
 
-    // Bind pipeline (skip if not compiled yet)
     if (s.pipeline.handle) |pipe| {
         dx.dx_bind_pipeline(dev, pipe);
     } else {
-        const k32 = struct {
-            extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
-        };
-        k32.OutputDebugStringA("RenderPass.step: pipeline handle is null, skipping\n");
-        return;
+        return; // Pipeline not compiled
     }
 
     // Set blend state

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -133,30 +133,6 @@ pub fn step(self: *Self, s: Step) void {
         .triangle_strip => 5, // D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP
     };
     if (s.draw.instance_count > 1) {
-        // Log instance count for cell_text draws
-        const ic: u32 = @intCast(s.draw.instance_count);
-        if (s.pipeline.layout_type == .cell_text) {
-            const k32 = struct {
-                extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
-                var last_count: u32 = 0;
-            };
-            if (ic != k32.last_count) {
-                k32.last_count = ic;
-                // Simple number output
-                var buf: [16]u8 = undefined;
-                buf[0] = 'I';
-                buf[1] = '=';
-                const n = ic;
-                var i: usize = 2;
-                if (n >= 1000) { buf[i] = '0' + @as(u8, @intCast((n / 1000) % 10)); i += 1; }
-                if (n >= 100) { buf[i] = '0' + @as(u8, @intCast((n / 100) % 10)); i += 1; }
-                if (n >= 10) { buf[i] = '0' + @as(u8, @intCast((n / 10) % 10)); i += 1; }
-                buf[i] = '0' + @as(u8, @intCast(n % 10)); i += 1;
-                buf[i] = '\n'; i += 1;
-                buf[i] = 0;
-                k32.OutputDebugStringA(@ptrCast(&buf));
-            }
-        }
         dx.dx_draw_instanced(dev,
             @intCast(s.draw.vertex_count),
             @intCast(s.draw.instance_count),

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -42,7 +42,6 @@ pub const Step = struct {
 };
 
 device: ?*anyopaque,
-cleared: bool = false,
 
 pub fn begin(device: ?*anyopaque, opts: Options) Self {
     _ = opts;
@@ -50,32 +49,16 @@ pub fn begin(device: ?*anyopaque, opts: Options) Self {
 }
 
 pub fn step(self: *Self, s: Step) void {
-    const DirectXMod = @import("../DirectX.zig");
     const dev = self.device orelse return;
 
     // Get pipeline handle (lazy creation on renderer thread)
     const pipe = s.pipeline.getHandle(dev) orelse return;
 
-    // On first step of the render pass, clear and set up backbuffer
-    if (!self.cleared) {
-        self.cleared = true;
-        var w: u32 = 0;
-        var h: u32 = 0;
-        dx.dx_get_backbuffer_size(dev, &w, &h);
-        dx.dx_set_viewport(dev, w, h);
-        dx.dx_bind_backbuffer(dev);
-        dx.dx_ensure_default_sampler(dev);
-        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
-        DirectXMod.current_device = dev;
-    }
-
-    // Set per-step D3D11 state
-    {
-        var w: u32 = 0;
-        var h: u32 = 0;
-        dx.dx_get_backbuffer_size(dev, &w, &h);
-        dx.dx_set_viewport(dev, w, h);
-    }
+    // Set D3D11 state (viewport/backbuffer already set by drawFrameStart)
+    var w: u32 = 0;
+    var h: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &w, &h);
+    dx.dx_set_viewport(dev, w, h);
     dx.dx_bind_backbuffer(dev);
     dx.dx_set_blend_enabled(dev, s.pipeline.blending_enabled);
     dx.dx_bind_pipeline(dev, pipe);
@@ -96,25 +79,17 @@ pub fn step(self: *Self, s: Step) void {
         .none => 0,
     };
 
-    // Bind buffers
+    // Bind vertex buffer (first buffer when pipeline has input layout)
     const has_vertex_data = (s.pipeline.layout_type != .none);
-    for (s.buffers, 0..) |buf_opt, i| {
-        if (buf_opt) |buf| {
-            if (i == 0 and has_vertex_data and vertex_stride > 0) {
-                // First buffer is vertex/instance data when pipeline has input layout
+    if (has_vertex_data and s.buffers.len > 0) {
+        if (s.buffers[0]) |buf| {
+            if (vertex_stride > 0) {
                 dx.dx_bind_vertex_buffer(dev, buf, vertex_stride, 0);
-            } else {
-                // SRV buffer: slot depends on whether first buffer was VB
-                const srv_slot: u32 = if (has_vertex_data)
-                    @intCast(i) // VB at 0, SRVs start at buffer index
-                else
-                    @intCast(i + 1); // no VB, SRVs at slot i+1
-                dx.dx_bind_srv_buffer(dev, buf, srv_slot, 4);
             }
         }
     }
 
-    // Bind textures
+    // Bind textures first (they occupy SRV slots 0..n-1)
     for (s.textures, 0..) |tex_opt, i| {
         if (tex_opt) |tex| {
             if (tex.dx_handle) |handle| {
@@ -128,6 +103,25 @@ pub fn step(self: *Self, s: Step) void {
         if (samp_opt) |samp| {
             if (samp.dx_handle) |handle| {
                 dx.dx_bind_sampler(dev, handle, @intCast(i));
+            }
+        }
+    }
+
+    // Bind SRV buffers AFTER textures.
+    // Slot = textures.len + srv_index (so they don't overlap texture slots).
+    // For cell_bg (no textures): bg_cells at slot 0+1=1 (register t1)
+    // For cell_text (2 textures): bg_colors at slot 2+0=2 (register t2)
+    {
+        const tex_count: u32 = @intCast(s.textures.len);
+        var srv_index: u32 = 0;
+        const start: usize = if (has_vertex_data) 1 else 0;
+        for (s.buffers[start..]) |buf_opt| {
+            if (buf_opt) |buf| {
+                // Slot 0 is reserved (cbuffer at b0 convention or first texture),
+                // so SRV buffers start at max(tex_count, 1) + srv_index
+                const base_slot = if (tex_count > 0) tex_count else 1;
+                dx.dx_bind_srv_buffer(dev, buf, base_slot + srv_index, 4);
+                srv_index += 1;
             }
         }
     }

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -63,23 +63,39 @@ pub fn step(self: *Self, s: Step) void {
     dx.dx_set_blend_enabled(dev, s.pipeline.blending_enabled);
     dx.dx_bind_pipeline(dev, pipe);
 
-    // Bind resources
+    // Clear previous SRV bindings (prevent slot conflicts between steps)
+    dx.dx_clear_shader_resources(dev);
+
+    // Bind uniform constant buffer at slot 1
     if (s.uniforms) |buf| {
         dx.dx_bind_constant_buffer(dev, buf, 1, true, true);
     }
 
+    // Determine vertex stride from pipeline layout type
+    const vertex_stride: u32 = switch (s.pipeline.layout_type) {
+        .cell_text => 32, // sizeof(CellText)
+        .bg_image => 8,   // sizeof(BgImage): f32 + u8 padded to 8
+        .image => 40,     // sizeof(Image): 2+2+4+2 floats = 40 bytes
+        .none => 0,
+    };
+
+    // Bind buffers
     for (s.buffers, 0..) |buf_opt, i| {
         if (buf_opt) |buf| {
-            if (i == 0 and s.draw.instance_count > 1) {
-                // First buffer is vertex/instance data for instanced draws
-                // Stride = size of one instance (CellText = 32 bytes)
-                dx.dx_bind_vertex_buffer(dev, buf, 32, 0);
+            if (i == 0 and s.draw.instance_count > 1 and vertex_stride > 0) {
+                dx.dx_bind_vertex_buffer(dev, buf, vertex_stride, 0);
             } else {
-                dx.dx_bind_srv_buffer(dev, buf, @intCast(i + 1), 4);
+                // SRV buffer: for cell_bg slot 1, for cell_text slot 2 (after VB)
+                const srv_slot: u32 = if (s.draw.instance_count > 1)
+                    @intCast(i) // instanced: slot 0 is VB, SRVs start at index
+                else
+                    @intCast(i + 1); // non-instanced: SRVs at slot i+1
+                dx.dx_bind_srv_buffer(dev, buf, srv_slot, 4);
             }
         }
     }
 
+    // Bind textures
     for (s.textures, 0..) |tex_opt, i| {
         if (tex_opt) |tex| {
             if (tex.dx_handle) |handle| {
@@ -88,6 +104,7 @@ pub fn step(self: *Self, s: Step) void {
         }
     }
 
+    // Bind samplers
     for (s.samplers, 0..) |samp_opt, i| {
         if (samp_opt) |samp| {
             if (samp.dx_handle) |handle| {

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const DirectX = @import("../DirectX.zig");
+const dx = DirectX.dx;
 const Pipeline = @import("Pipeline.zig");
 const Texture = @import("Texture.zig");
 const Sampler = @import("Sampler.zig");
@@ -39,18 +41,81 @@ pub const Step = struct {
     };
 };
 
-pub fn begin(opts: Options) Self {
-    _ = opts;
-    return .{};
+device: ?*anyopaque,
+
+pub fn begin(device: ?*anyopaque, opts: Options) Self {
+    const dev = device orelse return .{ .device = null };
+
+    // Clear attachments if requested
+    for (opts.attachments) |att| {
+        if (att.clear_color) |color| {
+            switch (att.target) {
+                .target => |t| {
+                    if (t.rt_handle) |rt| {
+                        dx.dx_bind_render_target(dev, rt);
+                        dx.dx_clear(dev, color[0], color[1], color[2], color[3]);
+                    }
+                },
+                .texture => {},
+            }
+        }
+    }
+
+    return .{ .device = dev };
 }
 
 pub fn step(self: *Self, s: Step) void {
-    _ = self;
-    _ = s;
-    // TODO: Record draw commands to D3D11 device context
+    const dev = self.device orelse return;
+
+    // Bind pipeline
+    if (s.pipeline.handle) |pipe| {
+        dx.dx_bind_pipeline(dev, pipe);
+    }
+
+    // Set blend state
+    dx.dx_set_blend_enabled(dev, s.pipeline.blending_enabled);
+
+    // Bind uniform constant buffer (slot 1 to match HLSL register(b1))
+    if (s.uniforms) |buf| {
+        dx.dx_bind_constant_buffer(dev, buf, 1, true, true);
+    }
+
+    // Bind structured buffers / vertex buffers
+    for (s.buffers, 0..) |buf_opt, i| {
+        if (buf_opt) |buf| {
+            dx.dx_bind_srv_buffer(dev, buf, @intCast(i + 1), 4);
+        }
+    }
+
+    // Bind textures
+    for (s.textures, 0..) |tex_opt, i| {
+        if (tex_opt) |tex| {
+            if (tex.dx_handle) |handle| {
+                dx.dx_bind_texture(dev, handle, @intCast(i));
+            }
+        }
+    }
+
+    // Bind samplers
+    for (s.samplers, 0..) |samp_opt, i| {
+        if (samp_opt) |samp| {
+            if (samp.dx_handle) |handle| {
+                dx.dx_bind_sampler(dev, handle, @intCast(i));
+            }
+        }
+    }
+
+    // Draw
+    if (s.draw.instance_count > 1) {
+        dx.dx_draw_instanced(dev,
+            @intCast(s.draw.vertex_count),
+            @intCast(s.draw.instance_count),
+            0, 0);
+    } else {
+        dx.dx_draw(dev, @intCast(s.draw.vertex_count), 0);
+    }
 }
 
 pub fn complete(self: *Self) void {
     _ = self;
-    // TODO: Execute recorded draw commands
 }

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -70,7 +70,13 @@ pub fn step(self: *Self, s: Step) void {
 
     for (s.buffers, 0..) |buf_opt, i| {
         if (buf_opt) |buf| {
-            dx.dx_bind_srv_buffer(dev, buf, @intCast(i + 1), 4);
+            if (i == 0 and s.draw.instance_count > 1) {
+                // First buffer is vertex/instance data for instanced draws
+                // Stride = size of one instance (CellText = 32 bytes)
+                dx.dx_bind_vertex_buffer(dev, buf, 32, 0);
+            } else {
+                dx.dx_bind_srv_buffer(dev, buf, @intCast(i + 1), 4);
+            }
         }
     }
 

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -42,6 +42,7 @@ pub const Step = struct {
 };
 
 device: ?*anyopaque,
+cleared: bool = false,
 
 pub fn begin(device: ?*anyopaque, opts: Options) Self {
     _ = opts;
@@ -49,16 +50,32 @@ pub fn begin(device: ?*anyopaque, opts: Options) Self {
 }
 
 pub fn step(self: *Self, s: Step) void {
+    const DirectXMod = @import("../DirectX.zig");
     const dev = self.device orelse return;
 
     // Get pipeline handle (lazy creation on renderer thread)
     const pipe = s.pipeline.getHandle(dev) orelse return;
 
-    // Set full D3D11 state
-    var w: u32 = 0;
-    var h: u32 = 0;
-    dx.dx_get_backbuffer_size(dev, &w, &h);
-    dx.dx_set_viewport(dev, w, h);
+    // On first step of the render pass, clear and set up backbuffer
+    if (!self.cleared) {
+        self.cleared = true;
+        var w: u32 = 0;
+        var h: u32 = 0;
+        dx.dx_get_backbuffer_size(dev, &w, &h);
+        dx.dx_set_viewport(dev, w, h);
+        dx.dx_bind_backbuffer(dev);
+        dx.dx_ensure_default_sampler(dev);
+        dx.dx_clear(dev, 0.0, 0.0, 0.0, 1.0);
+        DirectXMod.current_device = dev;
+    }
+
+    // Set per-step D3D11 state
+    {
+        var w: u32 = 0;
+        var h: u32 = 0;
+        dx.dx_get_backbuffer_size(dev, &w, &h);
+        dx.dx_set_viewport(dev, w, h);
+    }
     dx.dx_bind_backbuffer(dev);
     dx.dx_set_blend_enabled(dev, s.pipeline.blending_enabled);
     dx.dx_bind_pipeline(dev, pipe);
@@ -69,16 +86,6 @@ pub fn step(self: *Self, s: Step) void {
     // Bind uniform constant buffer at slot 1
     if (s.uniforms) |buf| {
         dx.dx_bind_constant_buffer(dev, buf, 1, true, true);
-    } else {
-        // Log once that uniforms is null
-        const k32 = struct {
-            extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
-            var logged: bool = false;
-        };
-        if (!k32.logged) {
-            k32.OutputDebugStringA("RenderPass: uniforms buffer is NULL\n");
-            k32.logged = true;
-        }
     }
 
     // Determine vertex stride from pipeline layout type

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -132,10 +132,11 @@ pub fn step(self: *Self, s: Step) void {
         .triangle => 4, // D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST
         .triangle_strip => 5, // D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP
     };
-    if (s.draw.instance_count > 1) {
+    if (s.draw.instance_count > 1 or has_vertex_data) {
+        const ic: u32 = @intCast(@max(s.draw.instance_count, 1));
         dx.dx_draw_instanced(dev,
             @intCast(s.draw.vertex_count),
-            @intCast(s.draw.instance_count),
+            ic,
             0, 0, topology);
     } else {
         dx.dx_draw(dev, @intCast(s.draw.vertex_count), 0, topology);

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -67,10 +67,15 @@ pub fn begin(device: ?*anyopaque, opts: Options) Self {
 pub fn step(self: *Self, s: Step) void {
     const dev = self.device orelse return;
 
-    if (s.pipeline.handle) |pipe| {
+    // Resolve pipeline handle (may need lazy creation from bytecode cache)
+    var pipeline = s.pipeline;
+    if (pipeline.handle == null) {
+        pipeline.createDeviceObjects(dev);
+    }
+    if (pipeline.handle) |pipe| {
         dx.dx_bind_pipeline(dev, pipe);
     } else {
-        return; // Pipeline not compiled
+        return;
     }
 
     // Set blend state

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const Pipeline = @import("Pipeline.zig");
+const Texture = @import("Texture.zig");
+const Sampler = @import("Sampler.zig");
+const Target = @import("Target.zig");
+const bufferpkg = @import("buffer.zig");
+
+const Self = @This();
+
+pub const Options = struct {
+    attachments: []const Attachment,
+
+    pub const Attachment = struct {
+        target: union(enum) {
+            texture: Texture,
+            target: Target,
+        },
+        clear_color: ?[4]f32 = null,
+    };
+};
+
+pub const Step = struct {
+    pipeline: Pipeline,
+    uniforms: ?bufferpkg.RawBuffer = null,
+    buffers: []const ?bufferpkg.RawBuffer = &.{},
+    textures: []const ?Texture = &.{},
+    samplers: []const ?Sampler = &.{},
+    draw: Draw,
+
+    pub const Draw = struct {
+        type: PrimitiveType,
+        vertex_count: usize,
+        instance_count: usize = 1,
+
+        pub const PrimitiveType = enum {
+            triangle,
+            triangle_strip,
+        };
+    };
+};
+
+pub fn begin(opts: Options) Self {
+    _ = opts;
+    return .{};
+}
+
+pub fn step(self: *Self, s: Step) void {
+    _ = self;
+    _ = s;
+    // TODO: Record draw commands to D3D11 device context
+}
+
+pub fn complete(self: *Self) void {
+    _ = self;
+    // TODO: Execute recorded draw commands
+}

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -71,7 +71,11 @@ pub fn step(self: *Self, s: Step) void {
     if (s.pipeline.handle) |pipe| {
         dx.dx_bind_pipeline(dev, pipe);
     } else {
-        return; // Pipeline not compiled, skip this draw
+        const k32 = struct {
+            extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
+        };
+        k32.OutputDebugStringA("RenderPass.step: pipeline handle is null, skipping\n");
+        return;
     }
 
     // Set blend state

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -74,22 +74,24 @@ pub fn step(self: *Self, s: Step) void {
     // Determine vertex stride from pipeline layout type
     const vertex_stride: u32 = switch (s.pipeline.layout_type) {
         .cell_text => 32, // sizeof(CellText)
-        .bg_image => 8,   // sizeof(BgImage): f32 + u8 padded to 8
+        .bg_image => 5,   // sizeof(BgImage): f32(4) + u8(1) = 5
         .image => 40,     // sizeof(Image): 2+2+4+2 floats = 40 bytes
         .none => 0,
     };
 
     // Bind buffers
+    const has_vertex_data = (s.pipeline.layout_type != .none);
     for (s.buffers, 0..) |buf_opt, i| {
         if (buf_opt) |buf| {
-            if (i == 0 and s.draw.instance_count > 1 and vertex_stride > 0) {
+            if (i == 0 and has_vertex_data and vertex_stride > 0) {
+                // First buffer is vertex/instance data when pipeline has input layout
                 dx.dx_bind_vertex_buffer(dev, buf, vertex_stride, 0);
             } else {
-                // SRV buffer: for cell_bg slot 1, for cell_text slot 2 (after VB)
-                const srv_slot: u32 = if (s.draw.instance_count > 1)
-                    @intCast(i) // instanced: slot 0 is VB, SRVs start at index
+                // SRV buffer: slot depends on whether first buffer was VB
+                const srv_slot: u32 = if (has_vertex_data)
+                    @intCast(i) // VB at 0, SRVs start at buffer index
                 else
-                    @intCast(i + 1); // non-instanced: SRVs at slot i+1
+                    @intCast(i + 1); // no VB, SRVs at slot i+1
                 dx.dx_bind_srv_buffer(dev, buf, srv_slot, 4);
             }
         }

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -44,56 +44,36 @@ pub const Step = struct {
 device: ?*anyopaque,
 
 pub fn begin(device: ?*anyopaque, opts: Options) Self {
-    const dev = device orelse return .{ .device = null };
-
-    // Clear attachments if requested
-    for (opts.attachments) |att| {
-        if (att.clear_color) |color| {
-            switch (att.target) {
-                .target => |t| {
-                    if (t.rt_handle) |rt| {
-                        dx.dx_bind_render_target(dev, rt);
-                        dx.dx_clear(dev, color[0], color[1], color[2], color[3]);
-                    }
-                },
-                .texture => {},
-            }
-        }
-    }
-
-    return .{ .device = dev };
+    _ = opts;
+    return .{ .device = device };
 }
 
 pub fn step(self: *Self, s: Step) void {
     const dev = self.device orelse return;
 
-    // Resolve pipeline handle (may need lazy creation from bytecode cache)
-    var pipeline = s.pipeline;
-    if (pipeline.handle == null) {
-        pipeline.createDeviceObjects(dev);
-    }
-    if (pipeline.handle) |pipe| {
-        dx.dx_bind_pipeline(dev, pipe);
-    } else {
-        return;
-    }
+    // Get pipeline handle (lazy creation on renderer thread)
+    const pipe = s.pipeline.getHandle(dev) orelse return;
 
-    // Set blend state
+    // Set full D3D11 state
+    var w: u32 = 0;
+    var h: u32 = 0;
+    dx.dx_get_backbuffer_size(dev, &w, &h);
+    dx.dx_set_viewport(dev, w, h);
+    dx.dx_bind_backbuffer(dev);
     dx.dx_set_blend_enabled(dev, s.pipeline.blending_enabled);
+    dx.dx_bind_pipeline(dev, pipe);
 
-    // Bind uniform constant buffer (slot 1 to match HLSL register(b1))
+    // Bind resources
     if (s.uniforms) |buf| {
         dx.dx_bind_constant_buffer(dev, buf, 1, true, true);
     }
 
-    // Bind structured buffers / vertex buffers
     for (s.buffers, 0..) |buf_opt, i| {
         if (buf_opt) |buf| {
             dx.dx_bind_srv_buffer(dev, buf, @intCast(i + 1), 4);
         }
     }
 
-    // Bind textures
     for (s.textures, 0..) |tex_opt, i| {
         if (tex_opt) |tex| {
             if (tex.dx_handle) |handle| {
@@ -102,7 +82,6 @@ pub fn step(self: *Self, s: Step) void {
         }
     }
 
-    // Bind samplers
     for (s.samplers, 0..) |samp_opt, i| {
         if (samp_opt) |samp| {
             if (samp.dx_handle) |handle| {

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -69,12 +69,22 @@ pub fn step(self: *Self, s: Step) void {
     // Bind uniform constant buffer at slot 1
     if (s.uniforms) |buf| {
         dx.dx_bind_constant_buffer(dev, buf, 1, true, true);
+    } else {
+        // Log once that uniforms is null
+        const k32 = struct {
+            extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
+            var logged: bool = false;
+        };
+        if (!k32.logged) {
+            k32.OutputDebugStringA("RenderPass: uniforms buffer is NULL\n");
+            k32.logged = true;
+        }
     }
 
     // Determine vertex stride from pipeline layout type
     const vertex_stride: u32 = switch (s.pipeline.layout_type) {
         .cell_text => 32, // sizeof(CellText)
-        .bg_image => 5,   // sizeof(BgImage): f32(4) + u8(1) = 5
+        .bg_image => 8,   // sizeof(BgImage): f32(4) + u8(1) + 3 padding = 8 (4-byte aligned)
         .image => 40,     // sizeof(Image): 2+2+4+2 floats = 40 bytes
         .none => 0,
     };

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -91,13 +91,17 @@ pub fn step(self: *Self, s: Step) void {
     }
 
     // Draw
+    const topology: u32 = switch (s.draw.type) {
+        .triangle => 4, // D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST
+        .triangle_strip => 5, // D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP
+    };
     if (s.draw.instance_count > 1) {
         dx.dx_draw_instanced(dev,
             @intCast(s.draw.vertex_count),
             @intCast(s.draw.instance_count),
-            0, 0);
+            0, 0, topology);
     } else {
-        dx.dx_draw(dev, @intCast(s.draw.vertex_count), 0);
+        dx.dx_draw(dev, @intCast(s.draw.vertex_count), 0, topology);
     }
 }
 

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -71,11 +71,12 @@ pub fn step(self: *Self, s: Step) void {
         dx.dx_bind_constant_buffer(dev, buf, 1, true, true);
     }
 
-    // Determine vertex stride from pipeline layout type
+    // Determine vertex stride from pipeline layout type using actual struct sizes
+    const shaders_mod = @import("shaders.zig");
     const vertex_stride: u32 = switch (s.pipeline.layout_type) {
-        .cell_text => 32, // sizeof(CellText)
-        .bg_image => 8,   // sizeof(BgImage): f32(4) + u8(1) + 3 padding = 8 (4-byte aligned)
-        .image => 40,     // sizeof(Image): 2+2+4+2 floats = 40 bytes
+        .cell_text => @sizeOf(shaders_mod.CellText),
+        .bg_image => @sizeOf(shaders_mod.BgImage),
+        .image => @sizeOf(shaders_mod.Image),
         .none => 0,
     };
 
@@ -132,6 +133,30 @@ pub fn step(self: *Self, s: Step) void {
         .triangle_strip => 5, // D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP
     };
     if (s.draw.instance_count > 1) {
+        // Log instance count for cell_text draws
+        const ic: u32 = @intCast(s.draw.instance_count);
+        if (s.pipeline.layout_type == .cell_text) {
+            const k32 = struct {
+                extern "kernel32" fn OutputDebugStringA([*:0]const u8) callconv(.winapi) void;
+                var last_count: u32 = 0;
+            };
+            if (ic != k32.last_count) {
+                k32.last_count = ic;
+                // Simple number output
+                var buf: [16]u8 = undefined;
+                buf[0] = 'I';
+                buf[1] = '=';
+                const n = ic;
+                var i: usize = 2;
+                if (n >= 1000) { buf[i] = '0' + @as(u8, @intCast((n / 1000) % 10)); i += 1; }
+                if (n >= 100) { buf[i] = '0' + @as(u8, @intCast((n / 100) % 10)); i += 1; }
+                if (n >= 10) { buf[i] = '0' + @as(u8, @intCast((n / 10) % 10)); i += 1; }
+                buf[i] = '0' + @as(u8, @intCast(n % 10)); i += 1;
+                buf[i] = '\n'; i += 1;
+                buf[i] = 0;
+                k32.OutputDebugStringA(@ptrCast(&buf));
+            }
+        }
         dx.dx_draw_instanced(dev,
             @intCast(s.draw.vertex_count),
             @intCast(s.draw.instance_count),

--- a/src/renderer/directx/RenderPass.zig
+++ b/src/renderer/directx/RenderPass.zig
@@ -67,9 +67,11 @@ pub fn begin(device: ?*anyopaque, opts: Options) Self {
 pub fn step(self: *Self, s: Step) void {
     const dev = self.device orelse return;
 
-    // Bind pipeline
+    // Bind pipeline (skip if not compiled yet)
     if (s.pipeline.handle) |pipe| {
         dx.dx_bind_pipeline(dev, pipe);
+    } else {
+        return; // Pipeline not compiled, skip this draw
     }
 
     // Set blend state

--- a/src/renderer/directx/Sampler.zig
+++ b/src/renderer/directx/Sampler.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const DirectX = @import("../DirectX.zig");
+const dx = DirectX.dx;
 
 const Self = @This();
 
@@ -14,15 +16,36 @@ pub const Options = struct {
     pub const Wrap = enum { clamp_to_edge, repeat };
 };
 
-dx_handle: ?*anyopaque = null, // DxSampler*
+// D3D11 filter modes
+const D3D11_FILTER_MIN_MAG_MIP_POINT: u32 = 0;
+const D3D11_FILTER_MIN_MAG_MIP_LINEAR: u32 = 0x15;
+// D3D11 address modes
+const D3D11_TEXTURE_ADDRESS_CLAMP: u32 = 3;
+const D3D11_TEXTURE_ADDRESS_WRAP: u32 = 1;
+
+dx_handle: ?*anyopaque = null,
 
 pub fn init(opts: Options) Error!Self {
-    _ = opts;
-    // TODO: call dx_create_sampler when device is available
-    return .{};
+    const dev = DirectX.current_device;
+    var handle: ?*anyopaque = null;
+
+    if (dev != null) {
+        const filter: u32 = if (opts.min_filter == .nearest and opts.mag_filter == .nearest)
+            D3D11_FILTER_MIN_MAG_MIP_POINT
+        else
+            D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+
+        const address: u32 = if (opts.wrap_s == .repeat)
+            D3D11_TEXTURE_ADDRESS_WRAP
+        else
+            D3D11_TEXTURE_ADDRESS_CLAMP;
+
+        handle = dx.dx_create_sampler(dev, filter, address);
+    }
+
+    return .{ .dx_handle = handle };
 }
 
 pub fn deinit(self: Self) void {
-    _ = self;
-    // TODO: dx_destroy_sampler
+    if (self.dx_handle) |h| dx.dx_destroy_sampler(h);
 }

--- a/src/renderer/directx/Sampler.zig
+++ b/src/renderer/directx/Sampler.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+const Self = @This();
+
+pub const Error = error{DirectXFailed};
+
+pub const Options = struct {
+    min_filter: Filter = .linear,
+    mag_filter: Filter = .linear,
+    wrap_s: Wrap = .clamp_to_edge,
+    wrap_t: Wrap = .clamp_to_edge,
+
+    pub const Filter = enum { nearest, linear };
+    pub const Wrap = enum { clamp_to_edge, repeat };
+};
+
+// TODO: ID3D11SamplerState
+
+pub fn init(opts: Options) Error!Self {
+    _ = opts;
+    return .{};
+}
+
+pub fn deinit(self: Self) void {
+    _ = self;
+}

--- a/src/renderer/directx/Sampler.zig
+++ b/src/renderer/directx/Sampler.zig
@@ -14,13 +14,15 @@ pub const Options = struct {
     pub const Wrap = enum { clamp_to_edge, repeat };
 };
 
-// TODO: ID3D11SamplerState
+dx_handle: ?*anyopaque = null, // DxSampler*
 
 pub fn init(opts: Options) Error!Self {
     _ = opts;
+    // TODO: call dx_create_sampler when device is available
     return .{};
 }
 
 pub fn deinit(self: Self) void {
     _ = self;
+    // TODO: dx_destroy_sampler
 }

--- a/src/renderer/directx/Target.zig
+++ b/src/renderer/directx/Target.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+const Self = @This();
+
+pub const Options = struct {
+    internal_format: InternalFormat,
+    width: usize,
+    height: usize,
+
+    pub const InternalFormat = enum { rgba, srgba };
+};
+
+width: u32,
+height: u32,
+// TODO: ID3D11RenderTargetView, ID3D11Texture2D
+
+pub fn init(opts: Options) !Self {
+    return .{
+        .width = @intCast(opts.width),
+        .height = @intCast(opts.height),
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.* = undefined;
+}

--- a/src/renderer/directx/Target.zig
+++ b/src/renderer/directx/Target.zig
@@ -12,7 +12,7 @@ pub const Options = struct {
 
 width: u32,
 height: u32,
-// TODO: ID3D11RenderTargetView, ID3D11Texture2D
+rt_handle: ?*anyopaque = null, // DxRenderTarget*
 
 pub fn init(opts: Options) !Self {
     return .{
@@ -22,5 +22,6 @@ pub fn init(opts: Options) !Self {
 }
 
 pub fn deinit(self: *Self) void {
+    // TODO: dx_destroy_render_target if rt_handle is set
     self.* = undefined;
 }

--- a/src/renderer/directx/Texture.zig
+++ b/src/renderer/directx/Texture.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const DirectX = @import("../DirectX.zig");
+const dx = DirectX.dx;
 
 const Self = @This();
 
@@ -21,31 +23,47 @@ pub const Options = struct {
     pub const Wrap = enum { clamp_to_edge, repeat };
 };
 
+// DXGI formats
+const DXGI_FORMAT_R8G8B8A8_UNORM: u32 = 28;
+const DXGI_FORMAT_B8G8R8A8_UNORM: u32 = 87;
+const DXGI_FORMAT_R8_UNORM: u32 = 61;
+
+fn dxgiFormat(format: Options.Format) u32 {
+    return switch (format) {
+        .rgba => DXGI_FORMAT_R8G8B8A8_UNORM,
+        .bgra => DXGI_FORMAT_B8G8R8A8_UNORM,
+        .red => DXGI_FORMAT_R8_UNORM,
+        .red_integer => DXGI_FORMAT_R8_UNORM,
+    };
+}
+
 width: usize,
 height: usize,
-dx_handle: ?*anyopaque = null, // DxTexture*
+dx_handle: ?*anyopaque = null,
 
 pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error!Self {
-    _ = opts;
-    _ = data;
-    // TODO: call dx_create_texture when device is available
+    const dev = DirectX.current_device;
+    var handle: ?*anyopaque = null;
+
+    if (dev != null and width > 0 and height > 0) {
+        const data_ptr: ?*const anyopaque = if (data) |d| @ptrCast(d.ptr) else null;
+        handle = dx.dx_create_texture(dev, @intCast(width), @intCast(height), dxgiFormat(opts.format), data_ptr);
+    }
+
     return .{
         .width = width,
         .height = height,
+        .dx_handle = handle,
     };
 }
 
 pub fn deinit(self: Self) void {
-    _ = self;
-    // TODO: dx_destroy_texture
+    if (self.dx_handle) |h| dx.dx_destroy_texture(h);
 }
 
 pub fn replaceRegion(self: *Self, offset_x: usize, offset_y: usize, rep_width: usize, rep_height: usize, data: []const u8) !void {
-    _ = self;
-    _ = offset_x;
-    _ = offset_y;
-    _ = rep_width;
-    _ = rep_height;
-    _ = data;
-    // TODO: dx_update_texture_region
+    const dev = DirectX.current_device orelse return;
+    if (self.dx_handle) |h| {
+        dx.dx_update_texture_region(dev, h, @intCast(offset_x), @intCast(offset_y), @intCast(rep_width), @intCast(rep_height), @ptrCast(data.ptr));
+    }
 }

--- a/src/renderer/directx/Texture.zig
+++ b/src/renderer/directx/Texture.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+
+const Self = @This();
+
+pub const Error = error{DirectXFailed};
+
+pub const Options = struct {
+    format: Format = .rgba,
+    internal_format: InternalFormat = .rgba,
+    target: TextureTarget = .texture_2d,
+    min_filter: MinFilter = .linear,
+    mag_filter: MagFilter = .linear,
+    wrap_s: Wrap = .clamp_to_edge,
+    wrap_t: Wrap = .clamp_to_edge,
+
+    pub const Format = enum { rgba, bgra, red, red_integer };
+    pub const InternalFormat = enum { rgba, srgba, red, r8, r32ui };
+    pub const TextureTarget = enum { texture_2d, texture_2d_array, texture_rectangle };
+    pub const MinFilter = enum { nearest, linear };
+    pub const MagFilter = enum { nearest, linear };
+    pub const Wrap = enum { clamp_to_edge, repeat };
+};
+
+width: usize,
+height: usize,
+// TODO: ID3D11Texture2D, ID3D11ShaderResourceView
+
+pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error!Self {
+    _ = opts;
+    _ = data;
+    return .{
+        .width = width,
+        .height = height,
+    };
+}
+
+pub fn deinit(self: Self) void {
+    _ = self;
+}
+
+pub fn replaceRegion(self: *Self, offset_x: usize, offset_y: usize, rep_width: usize, rep_height: usize, data: []const u8) !void {
+    _ = self;
+    _ = offset_x;
+    _ = offset_y;
+    _ = rep_width;
+    _ = rep_height;
+    _ = data;
+    // TODO: UpdateSubresource or Map/Unmap to update texture region
+}

--- a/src/renderer/directx/Texture.zig
+++ b/src/renderer/directx/Texture.zig
@@ -23,11 +23,12 @@ pub const Options = struct {
 
 width: usize,
 height: usize,
-// TODO: ID3D11Texture2D, ID3D11ShaderResourceView
+dx_handle: ?*anyopaque = null, // DxTexture*
 
 pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error!Self {
     _ = opts;
     _ = data;
+    // TODO: call dx_create_texture when device is available
     return .{
         .width = width,
         .height = height,
@@ -36,6 +37,7 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
 
 pub fn deinit(self: Self) void {
     _ = self;
+    // TODO: dx_destroy_texture
 }
 
 pub fn replaceRegion(self: *Self, offset_x: usize, offset_y: usize, rep_width: usize, rep_height: usize, data: []const u8) !void {
@@ -45,5 +47,5 @@ pub fn replaceRegion(self: *Self, offset_x: usize, offset_y: usize, rep_width: u
     _ = rep_width;
     _ = rep_height;
     _ = data;
-    // TODO: UpdateSubresource or Map/Unmap to update texture region
+    // TODO: dx_update_texture_region
 }

--- a/src/renderer/directx/buffer.zig
+++ b/src/renderer/directx/buffer.zig
@@ -90,13 +90,58 @@ pub fn Buffer(comptime T: type) type {
             self.len = data.len;
         }
 
-        pub fn syncFromArrayLists(self: *Self, lists: anytype) !usize {
-            _ = self;
-            var total: usize = 0;
+        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+            const dev = DirectX.current_device orelse return 0;
+
+            var total_len: usize = 0;
             for (lists) |list| {
-                total += list.items.len;
+                total_len += list.items.len;
             }
-            return total;
+            if (total_len == 0) return 0;
+
+            const byte_size: u32 = @intCast(total_len * @sizeOf(T));
+
+            // If buffer doesn't exist or is too small, recreate
+            if (self.buffer == null or total_len > self.len) {
+                if (self.buffer) |buf| dx.dx_destroy_buffer(buf);
+                self.len = total_len * 2;
+                const alloc_size: u32 = @intCast(self.len * @sizeOf(T));
+                self.buffer = dx.dx_create_buffer(
+                    dev,
+                    bindFlags(self.opts.target),
+                    alloc_size,
+                    null,
+                );
+            }
+
+            if (self.buffer == null) return 0;
+
+            // Copy all lists into a contiguous temporary buffer, then upload
+            // For efficiency with small data, stack-allocate up to 64KB
+            if (byte_size <= 65536) {
+                var tmp: [65536]u8 = undefined;
+                var offset: usize = 0;
+                for (lists) |list| {
+                    const items_bytes = std.mem.sliceAsBytes(list.items);
+                    @memcpy(tmp[offset..][0..items_bytes.len], items_bytes);
+                    offset += items_bytes.len;
+                }
+                dx.dx_update_buffer(dev, self.buffer, &tmp, byte_size);
+            } else {
+                // Large data: use heap allocation
+                const alloc = std.heap.page_allocator;
+                const tmp = alloc.alloc(u8, byte_size) catch return 0;
+                defer alloc.free(tmp);
+                var offset: usize = 0;
+                for (lists) |list| {
+                    const items_bytes = std.mem.sliceAsBytes(list.items);
+                    @memcpy(tmp[offset..][0..items_bytes.len], items_bytes);
+                    offset += items_bytes.len;
+                }
+                dx.dx_update_buffer(dev, self.buffer, tmp.ptr, byte_size);
+            }
+
+            return total_len;
         }
     };
 }

--- a/src/renderer/directx/buffer.zig
+++ b/src/renderer/directx/buffer.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const DirectX = @import("../DirectX.zig");
+const dx = DirectX.dx;
 
 pub const RawBuffer = ?*anyopaque;
 
@@ -20,6 +22,21 @@ pub const Options = struct {
     };
 };
 
+// D3D11 bind flags matching Options.Target
+const D3D11_BIND_VERTEX_BUFFER: u32 = 0x1;
+const D3D11_BIND_INDEX_BUFFER: u32 = 0x2;
+const D3D11_BIND_CONSTANT_BUFFER: u32 = 0x4;
+const D3D11_BIND_SHADER_RESOURCE: u32 = 0x8;
+
+fn bindFlags(target: Options.Target) u32 {
+    return switch (target) {
+        .array => D3D11_BIND_VERTEX_BUFFER,
+        .element_array => D3D11_BIND_INDEX_BUFFER,
+        .uniform => D3D11_BIND_CONSTANT_BUFFER,
+        .shader_storage => D3D11_BIND_SHADER_RESOURCE,
+    };
+}
+
 pub fn Buffer(comptime T: type) type {
     return struct {
         const Self = @This();
@@ -36,21 +53,41 @@ pub fn Buffer(comptime T: type) type {
         }
 
         pub fn initFill(opts: Options, data: []const T) !Self {
-            return .{
+            var self = Self{
                 .opts = opts,
                 .len = data.len,
             };
+            try self.sync(data);
+            return self;
         }
 
         pub fn deinit(self: Self) void {
-            _ = self;
-            // TODO: dx_destroy_buffer
+            if (self.buffer) |buf| dx.dx_destroy_buffer(buf);
         }
 
         pub fn sync(self: *Self, data: []const T) !void {
-            _ = self;
-            _ = data;
-            // TODO: dx_update_buffer
+            const dev = DirectX.current_device orelse return;
+            const byte_size: u32 = @intCast(data.len * @sizeOf(T));
+            if (byte_size == 0) return;
+
+            if (self.buffer) |buf| {
+                // Update existing buffer
+                dx.dx_update_buffer(dev, buf, @ptrCast(data.ptr), byte_size);
+            } else {
+                // Create new buffer
+                // Constant buffers must be 16-byte aligned
+                var aligned_size = byte_size;
+                if (self.opts.target == .uniform) {
+                    aligned_size = (byte_size + 15) & ~@as(u32, 15);
+                }
+                self.buffer = dx.dx_create_buffer(
+                    dev,
+                    bindFlags(self.opts.target),
+                    aligned_size,
+                    @ptrCast(data.ptr),
+                );
+            }
+            self.len = data.len;
         }
 
         pub fn syncFromArrayLists(self: *Self, lists: anytype) !usize {

--- a/src/renderer/directx/buffer.zig
+++ b/src/renderer/directx/buffer.zig
@@ -70,24 +70,32 @@ pub fn Buffer(comptime T: type) type {
             const byte_size: u32 = @intCast(data.len * @sizeOf(T));
             if (byte_size == 0) return;
 
+            // If buffer exists but is too small, recreate it
+            if (self.buffer != null and data.len > self.len) {
+                if (self.buffer) |buf| dx.dx_destroy_buffer(buf);
+                self.buffer = null;
+            }
+
             if (self.buffer) |buf| {
                 // Update existing buffer
                 dx.dx_update_buffer(dev, buf, @ptrCast(data.ptr), byte_size);
             } else {
-                // Create new buffer
-                // Constant buffers must be 16-byte aligned
-                var aligned_size = byte_size;
+                // Create new buffer with 2x capacity
+                const alloc_len = if (self.opts.target == .uniform) data.len else data.len * 2;
+                var alloc_size: u32 = @intCast(alloc_len * @sizeOf(T));
                 if (self.opts.target == .uniform) {
-                    aligned_size = (byte_size + 15) & ~@as(u32, 15);
+                    alloc_size = (alloc_size + 15) & ~@as(u32, 15);
                 }
                 self.buffer = dx.dx_create_buffer(
                     dev,
                     bindFlags(self.opts.target),
-                    aligned_size,
+                    alloc_size,
                     @ptrCast(data.ptr),
                 );
+                self.len = alloc_len;
+                return;
             }
-            self.len = data.len;
+            self.len = @max(self.len, data.len);
         }
 
         pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {

--- a/src/renderer/directx/buffer.zig
+++ b/src/renderer/directx/buffer.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub const RawBuffer = *anyopaque;
+pub const RawBuffer = ?*anyopaque;
 
 pub const Options = struct {
     target: Target = .array,
@@ -24,34 +24,33 @@ pub fn Buffer(comptime T: type) type {
     return struct {
         const Self = @This();
 
-        buffer: ?RawBuffer = null,
+        buffer: RawBuffer = null,
         opts: Options,
         len: usize,
 
         pub fn init(opts: Options, len: usize) !Self {
-            _ = opts;
             return .{
-                .opts = .{},
+                .opts = opts,
                 .len = len,
             };
         }
 
         pub fn initFill(opts: Options, data: []const T) !Self {
-            _ = opts;
             return .{
-                .opts = .{},
+                .opts = opts,
                 .len = data.len,
             };
         }
 
         pub fn deinit(self: Self) void {
             _ = self;
+            // TODO: dx_destroy_buffer
         }
 
         pub fn sync(self: *Self, data: []const T) !void {
             _ = self;
             _ = data;
-            // TODO: Map/Unmap D3D11 buffer
+            // TODO: dx_update_buffer
         }
 
         pub fn syncFromArrayLists(self: *Self, lists: anytype) !usize {
@@ -61,11 +60,6 @@ pub fn Buffer(comptime T: type) type {
                 total += list.items.len;
             }
             return total;
-        }
-
-        pub fn rawBuffer(self: Self) ?RawBuffer {
-            _ = self;
-            return null;
         }
     };
 }

--- a/src/renderer/directx/buffer.zig
+++ b/src/renderer/directx/buffer.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+
+pub const RawBuffer = *anyopaque;
+
+pub const Options = struct {
+    target: Target = .array,
+    usage: Usage = .dynamic_draw,
+
+    pub const Target = enum {
+        array,
+        element_array,
+        uniform,
+        shader_storage,
+    };
+
+    pub const Usage = enum {
+        static_draw,
+        dynamic_draw,
+        stream_draw,
+    };
+};
+
+pub fn Buffer(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        buffer: ?RawBuffer = null,
+        opts: Options,
+        len: usize,
+
+        pub fn init(opts: Options, len: usize) !Self {
+            _ = opts;
+            return .{
+                .opts = .{},
+                .len = len,
+            };
+        }
+
+        pub fn initFill(opts: Options, data: []const T) !Self {
+            _ = opts;
+            return .{
+                .opts = .{},
+                .len = data.len,
+            };
+        }
+
+        pub fn deinit(self: Self) void {
+            _ = self;
+        }
+
+        pub fn sync(self: *Self, data: []const T) !void {
+            _ = self;
+            _ = data;
+            // TODO: Map/Unmap D3D11 buffer
+        }
+
+        pub fn syncFromArrayLists(self: *Self, lists: anytype) !usize {
+            _ = self;
+            var total: usize = 0;
+            for (lists) |list| {
+                total += list.items.len;
+            }
+            return total;
+        }
+
+        pub fn rawBuffer(self: Self) ?RawBuffer {
+            _ = self;
+            return null;
+        }
+    };
+}

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -13,6 +13,7 @@
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "d3dcompiler.lib")
 
+#include <stdio.h>
 #include "d3d11_impl.h"
 
 // --- Device ---
@@ -341,12 +342,21 @@ struct DxPipeline {
 DxPipeline* dx_create_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
                                 const void* ps_bytecode, uint32_t ps_size,
                                 const void* input_desc, uint32_t input_count) {
+    char buf[128];
+    sprintf(buf, "D3D11: dx_create_pipeline vs=%p(%u) ps=%p(%u) dev=%p\n",
+        vs_bytecode, vs_size, ps_bytecode, ps_size, dev);
+    OutputDebugStringA(buf);
     if (!dev) return NULL;
     DxPipeline* pipe = (DxPipeline*)calloc(1, sizeof(DxPipeline));
     if (!pipe) return NULL;
 
-    ID3D11Device_CreateVertexShader(dev->device, vs_bytecode, vs_size, NULL, &pipe->vs);
-    ID3D11Device_CreatePixelShader(dev->device, ps_bytecode, ps_size, NULL, &pipe->ps);
+    HRESULT hr1 = ID3D11Device_CreateVertexShader(dev->device, vs_bytecode, vs_size, NULL, &pipe->vs);
+    HRESULT hr2 = ID3D11Device_CreatePixelShader(dev->device, ps_bytecode, ps_size, NULL, &pipe->ps);
+    {
+        char buf[128];
+        sprintf(buf, "D3D11: CreateShaders vs=%p(hr=%lX) ps=%p(hr=%lX)\n", pipe->vs, hr1, pipe->ps, hr2);
+        OutputDebugStringA(buf);
+    }
 
     if (input_desc && input_count > 0) {
         ID3D11Device_CreateInputLayout(dev->device, (const D3D11_INPUT_ELEMENT_DESC*)input_desc,
@@ -368,8 +378,7 @@ void dx_bind_pipeline(DxDevice* dev, DxPipeline* pipe) {
     if (!dev || !pipe) return;
     ID3D11DeviceContext_VSSetShader(dev->context, pipe->vs, NULL, 0);
     ID3D11DeviceContext_PSSetShader(dev->context, pipe->ps, NULL, 0);
-    if (pipe->input_layout)
-        ID3D11DeviceContext_IASetInputLayout(dev->context, pipe->input_layout);
+    ID3D11DeviceContext_IASetInputLayout(dev->context, pipe->input_layout); // NULL is OK for vertex-less draws
 }
 
 // --- Render Target ---
@@ -428,8 +437,15 @@ void dx_bind_render_target(DxDevice* dev, DxRenderTarget* rt) {
 
 // --- Draw ---
 
+static int draw_log_count = 0;
 void dx_draw(DxDevice* dev, uint32_t vertex_count, uint32_t start) {
     if (!dev) return;
+    if (draw_log_count < 5) {
+        char buf[64];
+        sprintf(buf, "D3D11: dx_draw count=%u start=%u\n", vertex_count, start);
+        OutputDebugStringA(buf);
+        draw_log_count++;
+    }
     ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     ID3D11DeviceContext_Draw(dev->context, vertex_count, start);
 }
@@ -446,6 +462,11 @@ void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_c
 DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
                                     const char* entry_point, const char* target) {
     DxCompiledShader result = {0};
+    {
+        char buf[128];
+        sprintf(buf, "D3D11: dx_compile_shader entry=%s target=%s len=%u\n", entry_point, target, source_len);
+        OutputDebugStringA(buf);
+    }
     ID3DBlob* blob = NULL;
     ID3DBlob* errors = NULL;
 

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -24,6 +24,7 @@ struct DxDevice {
     ID3D11RenderTargetView* backbuffer_rtv;
     ID3D11BlendState* blend_on;
     ID3D11BlendState* blend_off;
+    ID3D11RasterizerState* rasterizer_state;
     D3D_FEATURE_LEVEL feature_level;
     HWND hwnd;
 };
@@ -87,11 +88,26 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     bd.RenderTarget[0].BlendEnable = FALSE;
     ID3D11Device_CreateBlendState(dev->device, &bd, &dev->blend_off);
 
+    // Create rasterizer state with no culling (full-screen triangles have CCW winding in screen space)
+    D3D11_RASTERIZER_DESC rd = {0};
+    rd.FillMode = D3D11_FILL_SOLID;
+    rd.CullMode = D3D11_CULL_NONE;
+    rd.FrontCounterClockwise = FALSE;
+    rd.DepthClipEnable = TRUE;
+    rd.ScissorEnable = FALSE;
+    rd.MultisampleEnable = FALSE;
+    rd.AntialiasedLineEnable = FALSE;
+    ID3D11Device_CreateRasterizerState(dev->device, &rd, &dev->rasterizer_state);
+    if (dev->rasterizer_state) {
+        ID3D11DeviceContext_RSSetState(dev->context, dev->rasterizer_state);
+    }
+
     return dev;
 }
 
 void dx_destroy(DxDevice* dev) {
     if (!dev) return;
+    if (dev->rasterizer_state) ID3D11RasterizerState_Release(dev->rasterizer_state);
     if (dev->blend_off) ID3D11BlendState_Release(dev->blend_off);
     if (dev->blend_on) ID3D11BlendState_Release(dev->blend_on);
     if (dev->backbuffer_rtv) ID3D11RenderTargetView_Release(dev->backbuffer_rtv);
@@ -542,4 +558,47 @@ DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode,
 
     return dx_create_pipeline(dev, vs_bytecode, vs_size, ps_bytecode, ps_size,
                               layout, sizeof(layout) / sizeof(layout[0]));
+}
+
+// --- Debug test draw ---
+
+void dx_test_draw(DxDevice* dev) {
+    if (!dev) return;
+
+    static ID3D11VertexShader* test_vs = NULL;
+    static ID3D11PixelShader* test_ps = NULL;
+    static int initialized = 0;
+
+    if (!initialized) {
+        initialized = 1;
+        const char* shader_src =
+            "float4 vs_main(uint vid : SV_VertexID) : SV_Position {\n"
+            "  float2 pos[3] = { float2(0, 0.5), float2(0.5, -0.5), float2(-0.5, -0.5) };\n"
+            "  return float4(pos[vid], 0, 1);\n"
+            "}\n"
+            "float4 ps_main(float4 pos : SV_Position) : SV_Target {\n"
+            "  return float4(0, 1, 1, 1);\n"
+            "}\n";
+
+        DxCompiledShader vs = dx_compile_shader(shader_src, (uint32_t)strlen(shader_src), "vs_main", "vs_5_0");
+        DxCompiledShader ps = dx_compile_shader(shader_src, (uint32_t)strlen(shader_src), "ps_main", "ps_5_0");
+
+        if (vs.bytecode && ps.bytecode) {
+            ID3D11Device_CreateVertexShader(dev->device, vs.bytecode, vs.size, NULL, &test_vs);
+            ID3D11Device_CreatePixelShader(dev->device, ps.bytecode, ps.size, NULL, &test_ps);
+            OutputDebugStringA("dx_test_draw: shaders compiled OK\n");
+        } else {
+            OutputDebugStringA("dx_test_draw: shader compilation FAILED\n");
+        }
+        dx_free_compiled_shader(vs);
+        dx_free_compiled_shader(ps);
+    }
+
+    if (!test_vs || !test_ps) return;
+
+    ID3D11DeviceContext_VSSetShader(dev->context, test_vs, NULL, 0);
+    ID3D11DeviceContext_PSSetShader(dev->context, test_ps, NULL, 0);
+    ID3D11DeviceContext_IASetInputLayout(dev->context, NULL);
+    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ID3D11DeviceContext_Draw(dev->context, 3, 0);
 }

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -148,6 +148,21 @@ void dx_clear_shader_resources(DxDevice* dev) {
     ID3D11DeviceContext_PSSetShaderResources(dev->context, 0, 8, nullSRVs);
 }
 
+static ID3D11SamplerState* default_sampler = NULL;
+void dx_ensure_default_sampler(DxDevice* dev) {
+    if (!dev || default_sampler) return;
+    D3D11_SAMPLER_DESC sd = {0};
+    sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+    sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sd.MaxLOD = D3D11_FLOAT32_MAX;
+    ID3D11Device_CreateSamplerState(dev->device, &sd, &default_sampler);
+    if (default_sampler) {
+        ID3D11DeviceContext_PSSetSamplers(dev->context, 0, 1, &default_sampler);
+    }
+}
+
 void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height) {
     if (!dev) { *width = 0; *height = 0; return; }
     ID3D11Texture2D* back_buffer = NULL;
@@ -181,11 +196,8 @@ DxBuffer* dx_create_buffer(DxDevice* dev, uint32_t bind_flags, uint32_t byte_siz
     bd.Usage = D3D11_USAGE_DYNAMIC;
     bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-    // Structured buffers need misc flag
-    if (bind_flags & D3D11_BIND_SHADER_RESOURCE) {
-        bd.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
-        bd.StructureByteStride = 4; // Will be set properly by caller
-    }
+    // Shader resource buffers: use typed buffer (not structured)
+    // to avoid BUFFER_STRUCTURED compatibility issues
 
     D3D11_SUBRESOURCE_DATA sd = { .pSysMem = initial_data };
     HRESULT hr = ID3D11Device_CreateBuffer(dev->device, &bd, initial_data ? &sd : NULL, &buf->buffer);
@@ -228,7 +240,7 @@ void dx_bind_srv_buffer(DxDevice* dev, DxBuffer* buf, uint32_t slot, uint32_t el
     // Create SRV if not exists
     if (!buf->srv) {
         D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {0};
-        srv_desc.Format = DXGI_FORMAT_UNKNOWN;
+        srv_desc.Format = DXGI_FORMAT_R32_UINT;
         srv_desc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
         srv_desc.Buffer.FirstElement = 0;
         srv_desc.Buffer.NumElements = buf->byte_size / (element_size ? element_size : 4);

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -56,10 +56,7 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     scd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
 
     D3D_FEATURE_LEVEL feature_levels[] = { D3D_FEATURE_LEVEL_11_0 };
-    UINT flags = 0;
-#ifdef _DEBUG
-    flags |= D3D11_CREATE_DEVICE_DEBUG;
-#endif
+    UINT flags = D3D11_CREATE_DEVICE_DEBUG;
 
     HRESULT hr = D3D11CreateDeviceAndSwapChain(
         NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, flags,

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -94,6 +94,7 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
 }
 
 void dx_destroy(DxDevice* dev) {
+    OutputDebugStringA("D3D11: dx_destroy called\n");
     if (!dev) return;
     if (dev->blend_off) ID3D11BlendState_Release(dev->blend_off);
     if (dev->blend_on) ID3D11BlendState_Release(dev->blend_on);

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -27,6 +27,8 @@ struct DxDevice {
     ID3D11RasterizerState* rasterizer_state;
     D3D_FEATURE_LEVEL feature_level;
     HWND hwnd;
+    uint32_t bb_width;
+    uint32_t bb_height;
 };
 
 static void dx_create_backbuffer_rtv(DxDevice* dev) {
@@ -57,7 +59,10 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     scd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
 
     D3D_FEATURE_LEVEL feature_levels[] = { D3D_FEATURE_LEVEL_11_0 };
-    UINT flags = D3D11_CREATE_DEVICE_DEBUG;
+    UINT flags = 0;
+#ifndef NDEBUG
+    flags |= D3D11_CREATE_DEVICE_DEBUG;
+#endif
 
     HRESULT hr = D3D11CreateDeviceAndSwapChain(
         NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, flags,
@@ -72,6 +77,8 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     OutputDebugStringA("D3D11: Device created successfully\n");
 
     dx_create_backbuffer_rtv(dev);
+    dev->bb_width = width;
+    dev->bb_height = height;
 
     // Create blend states
     D3D11_BLEND_DESC bd = {0};
@@ -119,14 +126,27 @@ void dx_destroy(DxDevice* dev) {
 
 void dx_resize(DxDevice* dev, uint32_t width, uint32_t height) {
     if (!dev || width == 0 || height == 0) return;
-    // Release old RTV
+    if (dev->bb_width == width && dev->bb_height == height) return;
+
+    // Clear all state that references the backbuffer
+    ID3D11ShaderResourceView* nullSRVs[8] = {0};
+    ID3D11DeviceContext_PSSetShaderResources(dev->context, 0, 8, nullSRVs);
+    ID3D11DeviceContext_VSSetShaderResources(dev->context, 0, 8, nullSRVs);
+    ID3D11DeviceContext_OMSetRenderTargets(dev->context, 0, NULL, NULL);
+
     if (dev->backbuffer_rtv) {
-        ID3D11DeviceContext_OMSetRenderTargets(dev->context, 0, NULL, NULL);
         ID3D11RenderTargetView_Release(dev->backbuffer_rtv);
         dev->backbuffer_rtv = NULL;
     }
-    IDXGISwapChain_ResizeBuffers(dev->swap_chain, 0, width, height, DXGI_FORMAT_UNKNOWN, 0);
-    dx_create_backbuffer_rtv(dev);
+
+    ID3D11DeviceContext_Flush(dev->context);
+
+    HRESULT hr = IDXGISwapChain_ResizeBuffers(dev->swap_chain, 0, width, height, DXGI_FORMAT_UNKNOWN, 0);
+    if (SUCCEEDED(hr)) {
+        dx_create_backbuffer_rtv(dev);
+        dev->bb_width = width;
+        dev->bb_height = height;
+    }
 }
 
 void dx_present(DxDevice* dev, bool vsync) {
@@ -181,15 +201,8 @@ void dx_ensure_default_sampler(DxDevice* dev) {
 
 void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height) {
     if (!dev) { *width = 0; *height = 0; return; }
-    ID3D11Texture2D* back_buffer = NULL;
-    IDXGISwapChain_GetBuffer(dev->swap_chain, 0, &IID_ID3D11Texture2D, (void**)&back_buffer);
-    if (back_buffer) {
-        D3D11_TEXTURE2D_DESC desc;
-        ID3D11Texture2D_GetDesc(back_buffer, &desc);
-        *width = desc.Width;
-        *height = desc.Height;
-        ID3D11Texture2D_Release(back_buffer);
-    }
+    *width = dev->bb_width;
+    *height = dev->bb_height;
 }
 
 // --- Buffer ---
@@ -560,45 +573,3 @@ DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode,
                               layout, sizeof(layout) / sizeof(layout[0]));
 }
 
-// --- Debug test draw ---
-
-void dx_test_draw(DxDevice* dev) {
-    if (!dev) return;
-
-    static ID3D11VertexShader* test_vs = NULL;
-    static ID3D11PixelShader* test_ps = NULL;
-    static int initialized = 0;
-
-    if (!initialized) {
-        initialized = 1;
-        const char* shader_src =
-            "float4 vs_main(uint vid : SV_VertexID) : SV_Position {\n"
-            "  float2 pos[3] = { float2(0, 0.5), float2(0.5, -0.5), float2(-0.5, -0.5) };\n"
-            "  return float4(pos[vid], 0, 1);\n"
-            "}\n"
-            "float4 ps_main(float4 pos : SV_Position) : SV_Target {\n"
-            "  return float4(0, 1, 1, 1);\n"
-            "}\n";
-
-        DxCompiledShader vs = dx_compile_shader(shader_src, (uint32_t)strlen(shader_src), "vs_main", "vs_5_0");
-        DxCompiledShader ps = dx_compile_shader(shader_src, (uint32_t)strlen(shader_src), "ps_main", "ps_5_0");
-
-        if (vs.bytecode && ps.bytecode) {
-            ID3D11Device_CreateVertexShader(dev->device, vs.bytecode, vs.size, NULL, &test_vs);
-            ID3D11Device_CreatePixelShader(dev->device, ps.bytecode, ps.size, NULL, &test_ps);
-            OutputDebugStringA("dx_test_draw: shaders compiled OK\n");
-        } else {
-            OutputDebugStringA("dx_test_draw: shader compilation FAILED\n");
-        }
-        dx_free_compiled_shader(vs);
-        dx_free_compiled_shader(ps);
-    }
-
-    if (!test_vs || !test_ps) return;
-
-    ID3D11DeviceContext_VSSetShader(dev->context, test_vs, NULL, 0);
-    ID3D11DeviceContext_PSSetShader(dev->context, test_ps, NULL, 0);
-    ID3D11DeviceContext_IASetInputLayout(dev->context, NULL);
-    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    ID3D11DeviceContext_Draw(dev->context, 3, 0);
-}

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -141,6 +141,13 @@ void dx_set_blend_enabled(DxDevice* dev, bool enabled) {
     ID3D11DeviceContext_OMSetBlendState(dev->context, enabled ? dev->blend_on : dev->blend_off, blend_factor, 0xFFFFFFFF);
 }
 
+void dx_clear_shader_resources(DxDevice* dev) {
+    if (!dev) return;
+    ID3D11ShaderResourceView* nullSRVs[8] = {0};
+    ID3D11DeviceContext_VSSetShaderResources(dev->context, 0, 8, nullSRVs);
+    ID3D11DeviceContext_PSSetShaderResources(dev->context, 0, 8, nullSRVs);
+}
+
 void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height) {
     if (!dev) { *width = 0; *height = 0; return; }
     ID3D11Texture2D* back_buffer = NULL;
@@ -223,7 +230,8 @@ void dx_bind_srv_buffer(DxDevice* dev, DxBuffer* buf, uint32_t slot, uint32_t el
         D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {0};
         srv_desc.Format = DXGI_FORMAT_UNKNOWN;
         srv_desc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
-        srv_desc.Buffer.ElementWidth = buf->byte_size / (element_size ? element_size : 4);
+        srv_desc.Buffer.FirstElement = 0;
+        srv_desc.Buffer.NumElements = buf->byte_size / (element_size ? element_size : 4);
         ID3D11Device_CreateShaderResourceView(dev->device, (ID3D11Resource*)buf->buffer, &srv_desc, &buf->srv);
     }
     if (buf->srv) {
@@ -469,6 +477,32 @@ DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
 
 void dx_free_compiled_shader(DxCompiledShader shader) {
     free(shader.bytecode);
+}
+
+// Create pipeline with BgImage vertex input layout
+DxPipeline* dx_create_bg_image_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                         const void* ps_bytecode, uint32_t ps_size) {
+    if (!dev) return NULL;
+    D3D11_INPUT_ELEMENT_DESC layout[] = {
+        {"OPACITY", 0, DXGI_FORMAT_R32_FLOAT, 0, 0, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        {"INFO",    0, DXGI_FORMAT_R8_UINT,   0, 4, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+    };
+    return dx_create_pipeline(dev, vs_bytecode, vs_size, ps_bytecode, ps_size,
+                              layout, sizeof(layout) / sizeof(layout[0]));
+}
+
+// Create pipeline with Image vertex input layout
+DxPipeline* dx_create_image_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                      const void* ps_bytecode, uint32_t ps_size) {
+    if (!dev) return NULL;
+    D3D11_INPUT_ELEMENT_DESC layout[] = {
+        {"GRID_POS",    0, DXGI_FORMAT_R32G32_FLOAT,       0,  0, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        {"CELL_OFFSET", 0, DXGI_FORMAT_R32G32_FLOAT,       0,  8, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        {"SOURCE_RECT", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 16, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        {"DEST_SIZE",   0, DXGI_FORMAT_R32G32_FLOAT,       0, 32, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+    };
+    return dx_create_pipeline(dev, vs_bytecode, vs_size, ps_bytecode, ps_size,
+                              layout, sizeof(layout) / sizeof(layout[0]));
 }
 
 // Create pipeline with CellText vertex input layout

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -473,3 +473,30 @@ DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
 void dx_free_compiled_shader(DxCompiledShader shader) {
     free(shader.bytecode);
 }
+
+// Create pipeline with CellText vertex input layout
+// Matches the VSInput struct in cell_text.hlsl and CellText in shaders.zig
+DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                          const void* ps_bytecode, uint32_t ps_size) {
+    if (!dev) return NULL;
+
+    D3D11_INPUT_ELEMENT_DESC layout[] = {
+        // glyph_pos: uint2, offset 0
+        {"GLYPH_POS",    0, DXGI_FORMAT_R32G32_UINT,    0,  0, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        // glyph_size: uint2, offset 8
+        {"GLYPH_SIZE",   0, DXGI_FORMAT_R32G32_UINT,    0,  8, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        // bearings: int2 (i16x2), offset 16
+        {"BEARINGS",     0, DXGI_FORMAT_R16G16_SINT,    0, 16, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        // grid_pos: uint2 (u16x2), offset 20
+        {"GRID_POS",     0, DXGI_FORMAT_R16G16_UINT,    0, 20, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        // color: uint4 (u8x4), offset 24
+        {"COLOR",        0, DXGI_FORMAT_R8G8B8A8_UINT,  0, 24, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        // atlas: uint (u8), offset 28
+        {"ATLAS",        0, DXGI_FORMAT_R8_UINT,         0, 28, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+        // glyph_bools: uint (u8), offset 29
+        {"GLYPH_BOOLS",  0, DXGI_FORMAT_R8_UINT,         0, 29, D3D11_INPUT_PER_INSTANCE_DATA, 1},
+    };
+
+    return dx_create_pipeline(dev, vs_bytecode, vs_size, ps_bytecode, ps_size,
+                              layout, sizeof(layout) / sizeof(layout[0]));
+}

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -43,7 +43,7 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     dev->hwnd = (HWND)hwnd;
 
     DXGI_SWAP_CHAIN_DESC scd = {0};
-    scd.BufferCount = 2;
+    scd.BufferCount = 1;
     scd.BufferDesc.Width = width;
     scd.BufferDesc.Height = height;
     scd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -53,7 +53,7 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     scd.OutputWindow = dev->hwnd;
     scd.SampleDesc.Count = 1;
     scd.Windowed = TRUE;
-    scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+    scd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
 
     D3D_FEATURE_LEVEL feature_levels[] = { D3D_FEATURE_LEVEL_11_0 };
     UINT flags = 0;
@@ -67,9 +67,11 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
         &scd, &dev->swap_chain, &dev->device, &dev->feature_level, &dev->context);
 
     if (FAILED(hr)) {
+        OutputDebugStringA("D3D11: CreateDeviceAndSwapChain FAILED\n");
         free(dev);
         return NULL;
     }
+    OutputDebugStringA("D3D11: Device created successfully\n");
 
     dx_create_backbuffer_rtv(dev);
 

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -437,3 +437,38 @@ void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_c
     ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
     ID3D11DeviceContext_DrawInstanced(dev->context, vertex_count, instance_count, start_vertex, start_instance);
 }
+
+// --- Shader compilation ---
+
+DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
+                                    const char* entry_point, const char* target) {
+    DxCompiledShader result = {0};
+    ID3DBlob* blob = NULL;
+    ID3DBlob* errors = NULL;
+
+    HRESULT hr = D3DCompile(source, source_len, NULL, NULL, D3D_COMPILE_STANDARD_FILE_INCLUDE,
+        entry_point, target, D3DCOMPILE_OPTIMIZATION_LEVEL3, 0, &blob, &errors);
+
+    if (FAILED(hr)) {
+        if (errors) {
+            OutputDebugStringA("HLSL compile error: ");
+            OutputDebugStringA((const char*)ID3D10Blob_GetBufferPointer(errors));
+            OutputDebugStringA("\n");
+            ID3D10Blob_Release(errors);
+        }
+        return result;
+    }
+    if (errors) ID3D10Blob_Release(errors);
+
+    result.size = (uint32_t)ID3D10Blob_GetBufferSize(blob);
+    result.bytecode = malloc(result.size);
+    if (result.bytecode) {
+        memcpy(result.bytecode, ID3D10Blob_GetBufferPointer(blob), result.size);
+    }
+    ID3D10Blob_Release(blob);
+    return result;
+}
+
+void dx_free_compiled_shader(DxCompiledShader shader) {
+    free(shader.bytecode);
+}

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -13,7 +13,6 @@
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "d3dcompiler.lib")
 
-#include <stdio.h>
 #include "d3d11_impl.h"
 
 // --- Device ---
@@ -95,7 +94,6 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
 }
 
 void dx_destroy(DxDevice* dev) {
-    OutputDebugStringA("D3D11: dx_destroy called\n");
     if (!dev) return;
     if (dev->blend_off) ID3D11BlendState_Release(dev->blend_off);
     if (dev->blend_on) ID3D11BlendState_Release(dev->blend_on);
@@ -342,21 +340,12 @@ struct DxPipeline {
 DxPipeline* dx_create_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
                                 const void* ps_bytecode, uint32_t ps_size,
                                 const void* input_desc, uint32_t input_count) {
-    char buf[128];
-    sprintf(buf, "D3D11: dx_create_pipeline vs=%p(%u) ps=%p(%u) dev=%p\n",
-        vs_bytecode, vs_size, ps_bytecode, ps_size, dev);
-    OutputDebugStringA(buf);
     if (!dev) return NULL;
     DxPipeline* pipe = (DxPipeline*)calloc(1, sizeof(DxPipeline));
     if (!pipe) return NULL;
 
-    HRESULT hr1 = ID3D11Device_CreateVertexShader(dev->device, vs_bytecode, vs_size, NULL, &pipe->vs);
-    HRESULT hr2 = ID3D11Device_CreatePixelShader(dev->device, ps_bytecode, ps_size, NULL, &pipe->ps);
-    {
-        char buf[128];
-        sprintf(buf, "D3D11: CreateShaders vs=%p(hr=%lX) ps=%p(hr=%lX)\n", pipe->vs, hr1, pipe->ps, hr2);
-        OutputDebugStringA(buf);
-    }
+    ID3D11Device_CreateVertexShader(dev->device, vs_bytecode, vs_size, NULL, &pipe->vs);
+    ID3D11Device_CreatePixelShader(dev->device, ps_bytecode, ps_size, NULL, &pipe->ps);
 
     if (input_desc && input_count > 0) {
         ID3D11Device_CreateInputLayout(dev->device, (const D3D11_INPUT_ELEMENT_DESC*)input_desc,
@@ -437,23 +426,16 @@ void dx_bind_render_target(DxDevice* dev, DxRenderTarget* rt) {
 
 // --- Draw ---
 
-static int draw_log_count = 0;
-void dx_draw(DxDevice* dev, uint32_t vertex_count, uint32_t start) {
+void dx_draw(DxDevice* dev, uint32_t vertex_count, uint32_t start, uint32_t topology) {
     if (!dev) return;
-    if (draw_log_count < 5) {
-        char buf[64];
-        sprintf(buf, "D3D11: dx_draw count=%u start=%u\n", vertex_count, start);
-        OutputDebugStringA(buf);
-        draw_log_count++;
-    }
-    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, (D3D11_PRIMITIVE_TOPOLOGY)topology);
     ID3D11DeviceContext_Draw(dev->context, vertex_count, start);
 }
 
 void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_count,
-                        uint32_t start_vertex, uint32_t start_instance) {
+                        uint32_t start_vertex, uint32_t start_instance, uint32_t topology) {
     if (!dev) return;
-    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, (D3D11_PRIMITIVE_TOPOLOGY)topology);
     ID3D11DeviceContext_DrawInstanced(dev->context, vertex_count, instance_count, start_vertex, start_instance);
 }
 
@@ -462,11 +444,6 @@ void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_c
 DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
                                     const char* entry_point, const char* target) {
     DxCompiledShader result = {0};
-    {
-        char buf[128];
-        sprintf(buf, "D3D11: dx_compile_shader entry=%s target=%s len=%u\n", entry_point, target, source_len);
-        OutputDebugStringA(buf);
-    }
     ID3DBlob* blob = NULL;
     ID3DBlob* errors = NULL;
 

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -1,0 +1,439 @@
+// D3D11 implementation wrapper
+// Provides a flat C API over the COM-based D3D11 interfaces for Zig consumption.
+
+#define COBJMACROS
+#define WIN32_LEAN_AND_MEAN
+#define INITGUID
+#include <windows.h>
+#include <d3d11.h>
+#include <d3dcompiler.h>
+#include <dxgi.h>
+
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "d3dcompiler.lib")
+
+#include "d3d11_impl.h"
+
+// --- Device ---
+
+struct DxDevice {
+    ID3D11Device* device;
+    ID3D11DeviceContext* context;
+    IDXGISwapChain* swap_chain;
+    ID3D11RenderTargetView* backbuffer_rtv;
+    ID3D11BlendState* blend_on;
+    ID3D11BlendState* blend_off;
+    D3D_FEATURE_LEVEL feature_level;
+    HWND hwnd;
+};
+
+static void dx_create_backbuffer_rtv(DxDevice* dev) {
+    ID3D11Texture2D* back_buffer = NULL;
+    IDXGISwapChain_GetBuffer(dev->swap_chain, 0, &IID_ID3D11Texture2D, (void**)&back_buffer);
+    if (back_buffer) {
+        ID3D11Device_CreateRenderTargetView(dev->device, (ID3D11Resource*)back_buffer, NULL, &dev->backbuffer_rtv);
+        ID3D11Texture2D_Release(back_buffer);
+    }
+}
+
+DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
+    DxDevice* dev = (DxDevice*)calloc(1, sizeof(DxDevice));
+    if (!dev) return NULL;
+    dev->hwnd = (HWND)hwnd;
+
+    DXGI_SWAP_CHAIN_DESC scd = {0};
+    scd.BufferCount = 2;
+    scd.BufferDesc.Width = width;
+    scd.BufferDesc.Height = height;
+    scd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    scd.BufferDesc.RefreshRate.Numerator = 0;
+    scd.BufferDesc.RefreshRate.Denominator = 1;
+    scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    scd.OutputWindow = dev->hwnd;
+    scd.SampleDesc.Count = 1;
+    scd.Windowed = TRUE;
+    scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+
+    D3D_FEATURE_LEVEL feature_levels[] = { D3D_FEATURE_LEVEL_11_0 };
+    UINT flags = 0;
+#ifdef _DEBUG
+    flags |= D3D11_CREATE_DEVICE_DEBUG;
+#endif
+
+    HRESULT hr = D3D11CreateDeviceAndSwapChain(
+        NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, flags,
+        feature_levels, 1, D3D11_SDK_VERSION,
+        &scd, &dev->swap_chain, &dev->device, &dev->feature_level, &dev->context);
+
+    if (FAILED(hr)) {
+        free(dev);
+        return NULL;
+    }
+
+    dx_create_backbuffer_rtv(dev);
+
+    // Create blend states
+    D3D11_BLEND_DESC bd = {0};
+    bd.RenderTarget[0].BlendEnable = TRUE;
+    bd.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
+    bd.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+    bd.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+    bd.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+    bd.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+    bd.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+    bd.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+    ID3D11Device_CreateBlendState(dev->device, &bd, &dev->blend_on);
+
+    bd.RenderTarget[0].BlendEnable = FALSE;
+    ID3D11Device_CreateBlendState(dev->device, &bd, &dev->blend_off);
+
+    return dev;
+}
+
+void dx_destroy(DxDevice* dev) {
+    if (!dev) return;
+    if (dev->blend_off) ID3D11BlendState_Release(dev->blend_off);
+    if (dev->blend_on) ID3D11BlendState_Release(dev->blend_on);
+    if (dev->backbuffer_rtv) ID3D11RenderTargetView_Release(dev->backbuffer_rtv);
+    if (dev->swap_chain) IDXGISwapChain_Release(dev->swap_chain);
+    if (dev->context) ID3D11DeviceContext_Release(dev->context);
+    if (dev->device) ID3D11Device_Release(dev->device);
+    free(dev);
+}
+
+void dx_resize(DxDevice* dev, uint32_t width, uint32_t height) {
+    if (!dev || width == 0 || height == 0) return;
+    // Release old RTV
+    if (dev->backbuffer_rtv) {
+        ID3D11DeviceContext_OMSetRenderTargets(dev->context, 0, NULL, NULL);
+        ID3D11RenderTargetView_Release(dev->backbuffer_rtv);
+        dev->backbuffer_rtv = NULL;
+    }
+    IDXGISwapChain_ResizeBuffers(dev->swap_chain, 0, width, height, DXGI_FORMAT_UNKNOWN, 0);
+    dx_create_backbuffer_rtv(dev);
+}
+
+void dx_present(DxDevice* dev, bool vsync) {
+    if (!dev) return;
+    IDXGISwapChain_Present(dev->swap_chain, vsync ? 1 : 0, 0);
+}
+
+void dx_clear(DxDevice* dev, float r, float g, float b, float a) {
+    if (!dev || !dev->backbuffer_rtv) return;
+    float color[4] = { r, g, b, a };
+    ID3D11DeviceContext_ClearRenderTargetView(dev->context, dev->backbuffer_rtv, color);
+}
+
+void dx_set_viewport(DxDevice* dev, uint32_t width, uint32_t height) {
+    if (!dev) return;
+    D3D11_VIEWPORT vp = { 0, 0, (float)width, (float)height, 0.0f, 1.0f };
+    ID3D11DeviceContext_RSSetViewports(dev->context, 1, &vp);
+}
+
+void dx_bind_backbuffer(DxDevice* dev) {
+    if (!dev) return;
+    ID3D11DeviceContext_OMSetRenderTargets(dev->context, 1, &dev->backbuffer_rtv, NULL);
+}
+
+void dx_set_blend_enabled(DxDevice* dev, bool enabled) {
+    if (!dev) return;
+    float blend_factor[4] = { 0, 0, 0, 0 };
+    ID3D11DeviceContext_OMSetBlendState(dev->context, enabled ? dev->blend_on : dev->blend_off, blend_factor, 0xFFFFFFFF);
+}
+
+void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height) {
+    if (!dev) { *width = 0; *height = 0; return; }
+    ID3D11Texture2D* back_buffer = NULL;
+    IDXGISwapChain_GetBuffer(dev->swap_chain, 0, &IID_ID3D11Texture2D, (void**)&back_buffer);
+    if (back_buffer) {
+        D3D11_TEXTURE2D_DESC desc;
+        ID3D11Texture2D_GetDesc(back_buffer, &desc);
+        *width = desc.Width;
+        *height = desc.Height;
+        ID3D11Texture2D_Release(back_buffer);
+    }
+}
+
+// --- Buffer ---
+
+struct DxBuffer {
+    ID3D11Buffer* buffer;
+    ID3D11ShaderResourceView* srv;  // For structured buffers
+    uint32_t byte_size;
+};
+
+DxBuffer* dx_create_buffer(DxDevice* dev, uint32_t bind_flags, uint32_t byte_size, const void* initial_data) {
+    if (!dev) return NULL;
+    DxBuffer* buf = (DxBuffer*)calloc(1, sizeof(DxBuffer));
+    if (!buf) return NULL;
+    buf->byte_size = byte_size;
+
+    D3D11_BUFFER_DESC bd = {0};
+    bd.ByteWidth = byte_size;
+    bd.BindFlags = bind_flags;
+    bd.Usage = D3D11_USAGE_DYNAMIC;
+    bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+
+    // Structured buffers need misc flag
+    if (bind_flags & D3D11_BIND_SHADER_RESOURCE) {
+        bd.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        bd.StructureByteStride = 4; // Will be set properly by caller
+    }
+
+    D3D11_SUBRESOURCE_DATA sd = { .pSysMem = initial_data };
+    HRESULT hr = ID3D11Device_CreateBuffer(dev->device, &bd, initial_data ? &sd : NULL, &buf->buffer);
+    if (FAILED(hr)) { free(buf); return NULL; }
+
+    return buf;
+}
+
+void dx_destroy_buffer(DxBuffer* buf) {
+    if (!buf) return;
+    if (buf->srv) ID3D11ShaderResourceView_Release(buf->srv);
+    if (buf->buffer) ID3D11Buffer_Release(buf->buffer);
+    free(buf);
+}
+
+void dx_update_buffer(DxDevice* dev, DxBuffer* buf, const void* data, uint32_t byte_size) {
+    if (!dev || !buf || !data) return;
+    D3D11_MAPPED_SUBRESOURCE mapped;
+    HRESULT hr = ID3D11DeviceContext_Map(dev->context, (ID3D11Resource*)buf->buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+    if (SUCCEEDED(hr)) {
+        memcpy(mapped.pData, data, byte_size < buf->byte_size ? byte_size : buf->byte_size);
+        ID3D11DeviceContext_Unmap(dev->context, (ID3D11Resource*)buf->buffer, 0);
+    }
+}
+
+void dx_bind_vertex_buffer(DxDevice* dev, DxBuffer* buf, uint32_t stride, uint32_t slot) {
+    if (!dev || !buf) return;
+    UINT offset = 0;
+    ID3D11DeviceContext_IASetVertexBuffers(dev->context, slot, 1, &buf->buffer, &stride, &offset);
+}
+
+void dx_bind_constant_buffer(DxDevice* dev, DxBuffer* buf, uint32_t slot, bool vs, bool ps) {
+    if (!dev || !buf) return;
+    if (vs) ID3D11DeviceContext_VSSetConstantBuffers(dev->context, slot, 1, &buf->buffer);
+    if (ps) ID3D11DeviceContext_PSSetConstantBuffers(dev->context, slot, 1, &buf->buffer);
+}
+
+void dx_bind_srv_buffer(DxDevice* dev, DxBuffer* buf, uint32_t slot, uint32_t element_size) {
+    if (!dev || !buf) return;
+    // Create SRV if not exists
+    if (!buf->srv) {
+        D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {0};
+        srv_desc.Format = DXGI_FORMAT_UNKNOWN;
+        srv_desc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+        srv_desc.Buffer.ElementWidth = buf->byte_size / (element_size ? element_size : 4);
+        ID3D11Device_CreateShaderResourceView(dev->device, (ID3D11Resource*)buf->buffer, &srv_desc, &buf->srv);
+    }
+    if (buf->srv) {
+        ID3D11DeviceContext_VSSetShaderResources(dev->context, slot, 1, &buf->srv);
+        ID3D11DeviceContext_PSSetShaderResources(dev->context, slot, 1, &buf->srv);
+    }
+}
+
+// --- Texture ---
+
+struct DxTexture {
+    ID3D11Texture2D* texture;
+    ID3D11ShaderResourceView* srv;
+    uint32_t width;
+    uint32_t height;
+    DXGI_FORMAT format;
+};
+
+DxTexture* dx_create_texture(DxDevice* dev, uint32_t width, uint32_t height, uint32_t format, const void* data) {
+    if (!dev) return NULL;
+    DxTexture* tex = (DxTexture*)calloc(1, sizeof(DxTexture));
+    if (!tex) return NULL;
+    tex->width = width;
+    tex->height = height;
+    tex->format = (DXGI_FORMAT)format;
+
+    D3D11_TEXTURE2D_DESC td = {0};
+    td.Width = width;
+    td.Height = height;
+    td.MipLevels = 1;
+    td.ArraySize = 1;
+    td.Format = tex->format;
+    td.SampleDesc.Count = 1;
+    td.Usage = D3D11_USAGE_DEFAULT;
+    td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+
+    uint32_t bpp = (tex->format == DXGI_FORMAT_R8_UNORM) ? 1 : 4;
+    D3D11_SUBRESOURCE_DATA sd = { .pSysMem = data, .SysMemPitch = width * bpp };
+    HRESULT hr = ID3D11Device_CreateTexture2D(dev->device, &td, data ? &sd : NULL, &tex->texture);
+    if (FAILED(hr)) { free(tex); return NULL; }
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {0};
+    srv_desc.Format = tex->format;
+    srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+    srv_desc.Texture2D.MipLevels = 1;
+    ID3D11Device_CreateShaderResourceView(dev->device, (ID3D11Resource*)tex->texture, &srv_desc, &tex->srv);
+
+    return tex;
+}
+
+void dx_destroy_texture(DxTexture* tex) {
+    if (!tex) return;
+    if (tex->srv) ID3D11ShaderResourceView_Release(tex->srv);
+    if (tex->texture) ID3D11Texture2D_Release(tex->texture);
+    free(tex);
+}
+
+void dx_update_texture_region(DxDevice* dev, DxTexture* tex, uint32_t x, uint32_t y, uint32_t w, uint32_t h, const void* data) {
+    if (!dev || !tex || !data) return;
+    uint32_t bpp = (tex->format == DXGI_FORMAT_R8_UNORM) ? 1 : 4;
+    D3D11_BOX box = { x, y, 0, x + w, y + h, 1 };
+    ID3D11DeviceContext_UpdateSubresource(dev->context, (ID3D11Resource*)tex->texture, 0, &box, data, w * bpp, 0);
+}
+
+void dx_bind_texture(DxDevice* dev, DxTexture* tex, uint32_t slot) {
+    if (!dev || !tex || !tex->srv) return;
+    ID3D11DeviceContext_PSSetShaderResources(dev->context, slot, 1, &tex->srv);
+}
+
+// --- Sampler ---
+
+struct DxSampler {
+    ID3D11SamplerState* state;
+};
+
+DxSampler* dx_create_sampler(DxDevice* dev, uint32_t filter, uint32_t address_mode) {
+    if (!dev) return NULL;
+    DxSampler* samp = (DxSampler*)calloc(1, sizeof(DxSampler));
+    if (!samp) return NULL;
+
+    D3D11_SAMPLER_DESC sd = {0};
+    sd.Filter = (D3D11_FILTER)filter;
+    sd.AddressU = (D3D11_TEXTURE_ADDRESS_MODE)address_mode;
+    sd.AddressV = sd.AddressU;
+    sd.AddressW = sd.AddressU;
+    sd.MaxLOD = D3D11_FLOAT32_MAX;
+    ID3D11Device_CreateSamplerState(dev->device, &sd, &samp->state);
+
+    return samp;
+}
+
+void dx_destroy_sampler(DxSampler* samp) {
+    if (!samp) return;
+    if (samp->state) ID3D11SamplerState_Release(samp->state);
+    free(samp);
+}
+
+void dx_bind_sampler(DxDevice* dev, DxSampler* samp, uint32_t slot) {
+    if (!dev || !samp) return;
+    ID3D11DeviceContext_PSSetSamplers(dev->context, slot, 1, &samp->state);
+}
+
+// --- Pipeline ---
+
+struct DxPipeline {
+    ID3D11VertexShader* vs;
+    ID3D11PixelShader* ps;
+    ID3D11InputLayout* input_layout;
+};
+
+DxPipeline* dx_create_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                const void* ps_bytecode, uint32_t ps_size,
+                                const void* input_desc, uint32_t input_count) {
+    if (!dev) return NULL;
+    DxPipeline* pipe = (DxPipeline*)calloc(1, sizeof(DxPipeline));
+    if (!pipe) return NULL;
+
+    ID3D11Device_CreateVertexShader(dev->device, vs_bytecode, vs_size, NULL, &pipe->vs);
+    ID3D11Device_CreatePixelShader(dev->device, ps_bytecode, ps_size, NULL, &pipe->ps);
+
+    if (input_desc && input_count > 0) {
+        ID3D11Device_CreateInputLayout(dev->device, (const D3D11_INPUT_ELEMENT_DESC*)input_desc,
+            input_count, vs_bytecode, vs_size, &pipe->input_layout);
+    }
+
+    return pipe;
+}
+
+void dx_destroy_pipeline(DxPipeline* pipe) {
+    if (!pipe) return;
+    if (pipe->input_layout) ID3D11InputLayout_Release(pipe->input_layout);
+    if (pipe->ps) ID3D11PixelShader_Release(pipe->ps);
+    if (pipe->vs) ID3D11VertexShader_Release(pipe->vs);
+    free(pipe);
+}
+
+void dx_bind_pipeline(DxDevice* dev, DxPipeline* pipe) {
+    if (!dev || !pipe) return;
+    ID3D11DeviceContext_VSSetShader(dev->context, pipe->vs, NULL, 0);
+    ID3D11DeviceContext_PSSetShader(dev->context, pipe->ps, NULL, 0);
+    if (pipe->input_layout)
+        ID3D11DeviceContext_IASetInputLayout(dev->context, pipe->input_layout);
+}
+
+// --- Render Target ---
+
+struct DxRenderTarget {
+    ID3D11Texture2D* texture;
+    ID3D11RenderTargetView* rtv;
+    ID3D11ShaderResourceView* srv;
+    uint32_t width;
+    uint32_t height;
+};
+
+DxRenderTarget* dx_create_render_target(DxDevice* dev, uint32_t width, uint32_t height, uint32_t format) {
+    if (!dev) return NULL;
+    DxRenderTarget* rt = (DxRenderTarget*)calloc(1, sizeof(DxRenderTarget));
+    if (!rt) return NULL;
+    rt->width = width;
+    rt->height = height;
+
+    D3D11_TEXTURE2D_DESC td = {0};
+    td.Width = width;
+    td.Height = height;
+    td.MipLevels = 1;
+    td.ArraySize = 1;
+    td.Format = (DXGI_FORMAT)format;
+    td.SampleDesc.Count = 1;
+    td.Usage = D3D11_USAGE_DEFAULT;
+    td.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+    ID3D11Device_CreateTexture2D(dev->device, &td, NULL, &rt->texture);
+
+    if (rt->texture) {
+        ID3D11Device_CreateRenderTargetView(dev->device, (ID3D11Resource*)rt->texture, NULL, &rt->rtv);
+
+        D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {0};
+        srv_desc.Format = td.Format;
+        srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+        srv_desc.Texture2D.MipLevels = 1;
+        ID3D11Device_CreateShaderResourceView(dev->device, (ID3D11Resource*)rt->texture, &srv_desc, &rt->srv);
+    }
+
+    return rt;
+}
+
+void dx_destroy_render_target(DxRenderTarget* rt) {
+    if (!rt) return;
+    if (rt->srv) ID3D11ShaderResourceView_Release(rt->srv);
+    if (rt->rtv) ID3D11RenderTargetView_Release(rt->rtv);
+    if (rt->texture) ID3D11Texture2D_Release(rt->texture);
+    free(rt);
+}
+
+void dx_bind_render_target(DxDevice* dev, DxRenderTarget* rt) {
+    if (!dev || !rt) return;
+    ID3D11DeviceContext_OMSetRenderTargets(dev->context, 1, &rt->rtv, NULL);
+}
+
+// --- Draw ---
+
+void dx_draw(DxDevice* dev, uint32_t vertex_count, uint32_t start) {
+    if (!dev) return;
+    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ID3D11DeviceContext_Draw(dev->context, vertex_count, start);
+}
+
+void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_count,
+                        uint32_t start_vertex, uint32_t start_instance) {
+    if (!dev) return;
+    ID3D11DeviceContext_IASetPrimitiveTopology(dev->context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    ID3D11DeviceContext_DrawInstanced(dev->context, vertex_count, instance_count, start_vertex, start_instance);
+}

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -15,6 +15,10 @@
 
 #include "d3d11_impl.h"
 
+// Thread-safe window size (set by main thread, read by renderer thread)
+static volatile uint32_t g_window_width = 0;
+static volatile uint32_t g_window_height = 0;
+
 // --- Device ---
 
 struct DxDevice {
@@ -571,5 +575,17 @@ DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode,
 
     return dx_create_pipeline(dev, vs_bytecode, vs_size, ps_bytecode, ps_size,
                               layout, sizeof(layout) / sizeof(layout[0]));
+}
+
+// --- Window resize notification ---
+
+void dx_set_window_size(uint32_t width, uint32_t height) {
+    g_window_width = width;
+    g_window_height = height;
+}
+
+void dx_get_window_size(uint32_t* width, uint32_t* height) {
+    *width = g_window_width;
+    *height = g_window_height;
 }
 

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -53,8 +53,8 @@ void dx_destroy_pipeline(DxPipeline* pipe);
 void dx_bind_pipeline(DxDevice* dev, DxPipeline* pipe);
 
 // Draw
-void dx_draw(DxDevice* dev, uint32_t vertex_count, uint32_t start);
-void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_count, uint32_t start_vertex, uint32_t start_instance);
+void dx_draw(DxDevice* dev, uint32_t vertex_count, uint32_t start, uint32_t topology);
+void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_count, uint32_t start_vertex, uint32_t start_instance, uint32_t topology);
 
 // Render target
 typedef struct DxRenderTarget DxRenderTarget;

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -69,6 +69,15 @@ void dx_set_blend_enabled(DxDevice* dev, bool enabled);
 // Query
 void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height);
 
+// Shader compilation
+typedef struct DxCompiledShader {
+    void* bytecode;
+    uint32_t size;
+} DxCompiledShader;
+DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
+                                    const char* entry_point, const char* target);
+void dx_free_compiled_shader(DxCompiledShader shader);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -68,6 +68,7 @@ void dx_set_blend_enabled(DxDevice* dev, bool enabled);
 
 // State management
 void dx_clear_shader_resources(DxDevice* dev);
+void dx_ensure_default_sampler(DxDevice* dev);
 
 // Query
 void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height);

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -66,6 +66,9 @@ void dx_bind_backbuffer(DxDevice* dev);
 // Blend state
 void dx_set_blend_enabled(DxDevice* dev, bool enabled);
 
+// State management
+void dx_clear_shader_resources(DxDevice* dev);
+
 // Query
 void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height);
 
@@ -78,7 +81,11 @@ DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
                                     const char* entry_point, const char* target);
 void dx_free_compiled_shader(DxCompiledShader shader);
 
-// Create pipeline with CellText input layout
+// Specialized pipeline creation with input layouts
+DxPipeline* dx_create_bg_image_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                         const void* ps_bytecode, uint32_t ps_size);
+DxPipeline* dx_create_image_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                      const void* ps_bytecode, uint32_t ps_size);
 DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
                                           const void* ps_bytecode, uint32_t ps_size);
 

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -1,0 +1,74 @@
+// D3D11 implementation wrapper - C API for Zig consumption
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct DxDevice DxDevice;
+
+// Device creation
+DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height);
+void dx_destroy(DxDevice* dev);
+
+// Swap chain
+void dx_resize(DxDevice* dev, uint32_t width, uint32_t height);
+void dx_present(DxDevice* dev, bool vsync);
+
+// Frame operations
+void dx_clear(DxDevice* dev, float r, float g, float b, float a);
+void dx_set_viewport(DxDevice* dev, uint32_t width, uint32_t height);
+
+// Buffer operations
+typedef struct DxBuffer DxBuffer;
+DxBuffer* dx_create_buffer(DxDevice* dev, uint32_t bind_flags, uint32_t byte_size, const void* initial_data);
+void dx_destroy_buffer(DxBuffer* buf);
+void dx_update_buffer(DxDevice* dev, DxBuffer* buf, const void* data, uint32_t byte_size);
+void dx_bind_vertex_buffer(DxDevice* dev, DxBuffer* buf, uint32_t stride, uint32_t slot);
+void dx_bind_constant_buffer(DxDevice* dev, DxBuffer* buf, uint32_t slot, bool vs, bool ps);
+void dx_bind_srv_buffer(DxDevice* dev, DxBuffer* buf, uint32_t slot, uint32_t element_size);
+
+// Texture operations
+typedef struct DxTexture DxTexture;
+DxTexture* dx_create_texture(DxDevice* dev, uint32_t width, uint32_t height, uint32_t format, const void* data);
+void dx_destroy_texture(DxTexture* tex);
+void dx_update_texture_region(DxDevice* dev, DxTexture* tex, uint32_t x, uint32_t y, uint32_t w, uint32_t h, const void* data);
+void dx_bind_texture(DxDevice* dev, DxTexture* tex, uint32_t slot);
+
+// Sampler
+typedef struct DxSampler DxSampler;
+DxSampler* dx_create_sampler(DxDevice* dev, uint32_t filter, uint32_t address_mode);
+void dx_destroy_sampler(DxSampler* samp);
+void dx_bind_sampler(DxDevice* dev, DxSampler* samp, uint32_t slot);
+
+// Shader / Pipeline
+typedef struct DxPipeline DxPipeline;
+DxPipeline* dx_create_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                const void* ps_bytecode, uint32_t ps_size,
+                                const void* input_desc, uint32_t input_count);
+void dx_destroy_pipeline(DxPipeline* pipe);
+void dx_bind_pipeline(DxDevice* dev, DxPipeline* pipe);
+
+// Draw
+void dx_draw(DxDevice* dev, uint32_t vertex_count, uint32_t start);
+void dx_draw_instanced(DxDevice* dev, uint32_t vertex_count, uint32_t instance_count, uint32_t start_vertex, uint32_t start_instance);
+
+// Render target
+typedef struct DxRenderTarget DxRenderTarget;
+DxRenderTarget* dx_create_render_target(DxDevice* dev, uint32_t width, uint32_t height, uint32_t format);
+void dx_destroy_render_target(DxRenderTarget* rt);
+void dx_bind_render_target(DxDevice* dev, DxRenderTarget* rt);
+void dx_bind_backbuffer(DxDevice* dev);
+
+// Blend state
+void dx_set_blend_enabled(DxDevice* dev, bool enabled);
+
+// Query
+void dx_get_backbuffer_size(DxDevice* dev, uint32_t* width, uint32_t* height);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -78,6 +78,10 @@ DxCompiledShader dx_compile_shader(const char* source, uint32_t source_len,
                                     const char* entry_point, const char* target);
 void dx_free_compiled_shader(DxCompiledShader shader);
 
+// Create pipeline with CellText input layout
+DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
+                                          const void* ps_bytecode, uint32_t ps_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -90,9 +90,6 @@ DxPipeline* dx_create_image_pipeline(DxDevice* dev, const void* vs_bytecode, uin
 DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
                                           const void* ps_bytecode, uint32_t ps_size);
 
-// Debug test draw
-void dx_test_draw(DxDevice* dev);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -90,6 +90,9 @@ DxPipeline* dx_create_image_pipeline(DxDevice* dev, const void* vs_bytecode, uin
 DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
                                           const void* ps_bytecode, uint32_t ps_size);
 
+// Debug test draw
+void dx_test_draw(DxDevice* dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -90,6 +90,10 @@ DxPipeline* dx_create_image_pipeline(DxDevice* dev, const void* vs_bytecode, uin
 DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
                                           const void* ps_bytecode, uint32_t ps_size);
 
+// Window resize notification (thread-safe, called from main thread)
+void dx_set_window_size(uint32_t width, uint32_t height);
+void dx_get_window_size(uint32_t* width, uint32_t* height);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/renderer/directx/shaders.zig
+++ b/src/renderer/directx/shaders.zig
@@ -1,0 +1,159 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const math = @import("../../math.zig");
+
+const Pipeline = @import("Pipeline.zig");
+
+const log = std.log.scoped(.directx);
+
+// Re-use the same data types as OpenGL - these define the GPU buffer layouts
+// and must match the HLSL constant buffer / structured buffer definitions.
+pub const Uniforms = extern struct {
+    projection_matrix: math.Mat align(16),
+    screen_size: [2]f32 align(8),
+    cell_size: [2]f32 align(8),
+    grid_size: [2]u16 align(4),
+    grid_padding: [4]f32 align(16),
+    padding_extend: PaddingExtend align(4),
+    min_contrast: f32 align(4),
+    cursor_pos: [2]u16 align(4),
+    cursor_color: [4]u8 align(4),
+    bg_color: [4]u8 align(4),
+    bools: Bools align(4),
+
+    const Bools = packed struct(u32) {
+        cursor_wide: bool,
+        use_display_p3: bool,
+        use_linear_blending: bool,
+        use_linear_correction: bool = false,
+        _padding: u28 = 0,
+    };
+
+    const PaddingExtend = packed struct(u32) {
+        left: bool = false,
+        right: bool = false,
+        up: bool = false,
+        down: bool = false,
+        _padding: u28 = 0,
+    };
+};
+
+pub const CellText = extern struct {
+    glyph_pos: [2]u32 align(8) = .{ 0, 0 },
+    glyph_size: [2]u32 align(8) = .{ 0, 0 },
+    bearings: [2]i16 align(4) = .{ 0, 0 },
+    grid_pos: [2]u16 align(4),
+    color: [4]u8 align(4),
+    atlas: Atlas align(1),
+    bools: packed struct(u8) {
+        no_min_contrast: bool = false,
+        is_cursor_glyph: bool = false,
+        _padding: u6 = 0,
+    } align(1) = .{},
+
+    pub const Atlas = enum(u8) {
+        grayscale = 0,
+        color = 1,
+    };
+};
+
+pub const CellBg = [4]u8;
+
+pub const Image = extern struct {
+    grid_pos: [2]f32 align(8),
+    cell_offset: [2]f32 align(8),
+    source_rect: [4]f32 align(16),
+    dest_size: [2]f32 align(8),
+};
+
+pub const BgImage = extern struct {
+    opacity: f32 align(4),
+    info: Info align(1),
+
+    pub const Info = packed struct(u8) {
+        position: Position,
+        fit: Fit,
+        repeat: bool,
+        _padding: u1 = 0,
+
+        pub const Position = enum(u4) {
+            tl = 0,
+            tc = 1,
+            tr = 2,
+            ml = 3,
+            mc = 4,
+            mr = 5,
+            bl = 6,
+            bc = 7,
+            br = 8,
+        };
+
+        pub const Fit = enum(u2) {
+            contain = 0,
+            cover = 1,
+            stretch = 2,
+            none = 3,
+        };
+    };
+};
+
+pub const Shaders = struct {
+    pipelines: PipelineCollection,
+    post_pipelines: []const Pipeline,
+    defunct: bool = false,
+
+    pub const PipelineCollection = struct {
+        bg_color: Pipeline,
+        cell_bg: Pipeline,
+        cell_text: Pipeline,
+        image: Pipeline,
+        bg_image: Pipeline,
+    };
+
+    pub fn init(
+        alloc: Allocator,
+        custom_shaders: []const [:0]const u8,
+    ) !Shaders {
+        _ = alloc;
+        _ = custom_shaders;
+        // TODO: Compile HLSL shaders and create pipelines
+        return .{
+            .pipelines = .{
+                .bg_color = try Pipeline.init(null, .{
+                    .vertex_fn = "bg_color_vs",
+                    .fragment_fn = "bg_color_ps",
+                    .blending_enabled = false,
+                }),
+                .cell_bg = try Pipeline.init(null, .{
+                    .vertex_fn = "cell_bg_vs",
+                    .fragment_fn = "cell_bg_ps",
+                }),
+                .cell_text = try Pipeline.init(CellText, .{
+                    .vertex_fn = "cell_text_vs",
+                    .fragment_fn = "cell_text_ps",
+                    .step_fn = .per_instance,
+                }),
+                .image = try Pipeline.init(Image, .{
+                    .vertex_fn = "image_vs",
+                    .fragment_fn = "image_ps",
+                    .step_fn = .per_instance,
+                }),
+                .bg_image = try Pipeline.init(BgImage, .{
+                    .vertex_fn = "bg_image_vs",
+                    .fragment_fn = "bg_image_ps",
+                    .step_fn = .per_instance,
+                }),
+            },
+            .post_pipelines = &.{},
+        };
+    }
+
+    pub fn deinit(self: *Shaders, alloc: Allocator) void {
+        _ = alloc;
+        self.pipelines.bg_color.deinit();
+        self.pipelines.cell_bg.deinit();
+        self.pipelines.cell_text.deinit();
+        self.pipelines.image.deinit();
+        self.pipelines.bg_image.deinit();
+    }
+};

--- a/src/renderer/directx/shaders.zig
+++ b/src/renderer/directx/shaders.zig
@@ -149,12 +149,12 @@ pub const Shaders = struct {
     /// Compile all HLSL shaders on the D3D11 device.
     /// Called once when the device is available.
     /// Step 1: Compile HLSL to bytecode (no device needed).
-    pub fn compileBytecode(self: *Shaders) void {
-        self.pipelines.bg_color.compileBytecode(hlsl_bg_color, hlsl_bg_color);
-        self.pipelines.cell_bg.compileBytecode(hlsl_cell_bg, hlsl_cell_bg);
-        self.pipelines.cell_text.compileBytecode(hlsl_cell_text, hlsl_cell_text);
-        self.pipelines.image.compileBytecode(hlsl_image, hlsl_image);
-        self.pipelines.bg_image.compileBytecode(hlsl_bg_image, hlsl_bg_image);
+    pub fn storeSource(self: *Shaders) void {
+        self.pipelines.bg_color.storeSource(hlsl_bg_color, hlsl_bg_color);
+        self.pipelines.cell_bg.storeSource(hlsl_cell_bg, hlsl_cell_bg);
+        self.pipelines.cell_text.storeSource(hlsl_cell_text, hlsl_cell_text);
+        self.pipelines.image.storeSource(hlsl_image, hlsl_image);
+        self.pipelines.bg_image.storeSource(hlsl_bg_image, hlsl_bg_image);
     }
 
     /// Step 2: Create D3D11 shader objects from bytecode (needs device, renderer thread).

--- a/src/renderer/directx/shaders.zig
+++ b/src/renderer/directx/shaders.zig
@@ -148,27 +148,24 @@ pub const Shaders = struct {
 
     /// Compile all HLSL shaders on the D3D11 device.
     /// Called once when the device is available.
-    /// Try to compile shaders. Can be called multiple times - only compiles
-    /// pipelines that don't have a handle yet.
-    pub fn compileAll(self: *Shaders, device: ?*anyopaque) void {
+    /// Step 1: Compile HLSL to bytecode (no device needed).
+    pub fn compileBytecode(self: *Shaders) void {
+        self.pipelines.bg_color.compileBytecode(hlsl_bg_color, hlsl_bg_color);
+        self.pipelines.cell_bg.compileBytecode(hlsl_cell_bg, hlsl_cell_bg);
+        self.pipelines.cell_text.compileBytecode(hlsl_cell_text, hlsl_cell_text);
+        self.pipelines.image.compileBytecode(hlsl_image, hlsl_image);
+        self.pipelines.bg_image.compileBytecode(hlsl_bg_image, hlsl_bg_image);
+    }
+
+    /// Step 2: Create D3D11 shader objects from bytecode (needs device, renderer thread).
+    pub fn createDeviceObjects(self: *Shaders, device: ?*anyopaque) void {
         if (device == null) return;
         self.device = device;
-        log.info("compiling HLSL shaders...", .{});
-        self.pipelines.bg_color.createOnDevice(device, hlsl_bg_color, hlsl_bg_color) catch
-            log.err("failed to compile bg_color shader", .{});
-        log.info("bg_color: handle={?}", .{self.pipelines.bg_color.handle});
-        self.pipelines.cell_bg.createOnDevice(device, hlsl_cell_bg, hlsl_cell_bg) catch
-            log.err("failed to compile cell_bg shader", .{});
-        log.info("cell_bg: handle={?}", .{self.pipelines.cell_bg.handle});
-        self.pipelines.cell_text.createOnDevice(device, hlsl_cell_text, hlsl_cell_text) catch
-            log.err("failed to compile cell_text shader", .{});
-        log.info("cell_text: handle={?}", .{self.pipelines.cell_text.handle});
-        self.pipelines.image.createOnDevice(device, hlsl_image, hlsl_image) catch
-            log.err("failed to compile image shader", .{});
-        log.info("image: handle={?}", .{self.pipelines.image.handle});
-        self.pipelines.bg_image.createOnDevice(device, hlsl_bg_image, hlsl_bg_image) catch
-            log.err("failed to compile bg_image shader", .{});
-        log.info("bg_image: handle={?}", .{self.pipelines.bg_image.handle});
+        self.pipelines.bg_color.createDeviceObjects(device);
+        self.pipelines.cell_bg.createDeviceObjects(device);
+        self.pipelines.cell_text.createDeviceObjects(device);
+        self.pipelines.image.createDeviceObjects(device);
+        self.pipelines.bg_image.createDeviceObjects(device);
     }
 
     pub fn deinit(self: *Shaders, alloc: Allocator) void {

--- a/src/renderer/directx/shaders.zig
+++ b/src/renderer/directx/shaders.zig
@@ -148,18 +148,27 @@ pub const Shaders = struct {
 
     /// Compile all HLSL shaders on the D3D11 device.
     /// Called once when the device is available.
+    /// Try to compile shaders. Can be called multiple times - only compiles
+    /// pipelines that don't have a handle yet.
     pub fn compileAll(self: *Shaders, device: ?*anyopaque) void {
+        if (device == null) return;
         self.device = device;
+        log.info("compiling HLSL shaders...", .{});
         self.pipelines.bg_color.createOnDevice(device, hlsl_bg_color, hlsl_bg_color) catch
             log.err("failed to compile bg_color shader", .{});
+        log.info("bg_color: handle={?}", .{self.pipelines.bg_color.handle});
         self.pipelines.cell_bg.createOnDevice(device, hlsl_cell_bg, hlsl_cell_bg) catch
             log.err("failed to compile cell_bg shader", .{});
+        log.info("cell_bg: handle={?}", .{self.pipelines.cell_bg.handle});
         self.pipelines.cell_text.createOnDevice(device, hlsl_cell_text, hlsl_cell_text) catch
             log.err("failed to compile cell_text shader", .{});
+        log.info("cell_text: handle={?}", .{self.pipelines.cell_text.handle});
         self.pipelines.image.createOnDevice(device, hlsl_image, hlsl_image) catch
             log.err("failed to compile image shader", .{});
+        log.info("image: handle={?}", .{self.pipelines.image.handle});
         self.pipelines.bg_image.createOnDevice(device, hlsl_bg_image, hlsl_bg_image) catch
             log.err("failed to compile bg_image shader", .{});
+        log.info("bg_image: handle={?}", .{self.pipelines.bg_image.handle});
     }
 
     pub fn deinit(self: *Shaders, alloc: Allocator) void {

--- a/src/renderer/directx/shaders.zig
+++ b/src/renderer/directx/shaders.zig
@@ -6,8 +6,15 @@ const Pipeline = @import("Pipeline.zig");
 
 const log = std.log.scoped(.directx);
 
-// Re-use the same data types as OpenGL - these define the GPU buffer layouts
-// and must match the HLSL constant buffer / structured buffer definitions.
+// Embed HLSL source at comptime (with #include resolved)
+const hlsl_common = @embedFile("../shaders/hlsl/common.hlsl");
+const hlsl_bg_color = hlsl_common ++ @embedFile("../shaders/hlsl/bg_color.hlsl");
+const hlsl_cell_bg = hlsl_common ++ @embedFile("../shaders/hlsl/cell_bg.hlsl");
+const hlsl_cell_text = hlsl_common ++ @embedFile("../shaders/hlsl/cell_text.hlsl");
+const hlsl_image = hlsl_common ++ @embedFile("../shaders/hlsl/image.hlsl");
+const hlsl_bg_image = hlsl_common ++ @embedFile("../shaders/hlsl/bg_image.hlsl");
+
+// GPU data types (must match HLSL constant buffer layouts)
 pub const Uniforms = extern struct {
     projection_matrix: math.Mat align(16),
     screen_size: [2]f32 align(8),
@@ -77,22 +84,13 @@ pub const BgImage = extern struct {
         _padding: u1 = 0,
 
         pub const Position = enum(u4) {
-            tl = 0,
-            tc = 1,
-            tr = 2,
-            ml = 3,
-            mc = 4,
-            mr = 5,
-            bl = 6,
-            bc = 7,
-            br = 8,
+            tl = 0, tc = 1, tr = 2,
+            ml = 3, mc = 4, mr = 5,
+            bl = 6, bc = 7, br = 8,
         };
 
         pub const Fit = enum(u2) {
-            contain = 0,
-            cover = 1,
-            stretch = 2,
-            none = 3,
+            contain = 0, cover = 1, stretch = 2, none = 3,
         };
     };
 };
@@ -101,6 +99,7 @@ pub const Shaders = struct {
     pipelines: PipelineCollection,
     post_pipelines: []const Pipeline,
     defunct: bool = false,
+    device: ?*anyopaque = null,
 
     pub const PipelineCollection = struct {
         bg_color: Pipeline,
@@ -116,36 +115,51 @@ pub const Shaders = struct {
     ) !Shaders {
         _ = alloc;
         _ = custom_shaders;
-        // TODO: Compile HLSL shaders and create pipelines
         return .{
             .pipelines = .{
                 .bg_color = try Pipeline.init(null, .{
-                    .vertex_fn = "bg_color_vs",
-                    .fragment_fn = "bg_color_ps",
+                    .vertex_fn = "vs_main",
+                    .fragment_fn = "ps_main",
                     .blending_enabled = false,
                 }),
                 .cell_bg = try Pipeline.init(null, .{
-                    .vertex_fn = "cell_bg_vs",
-                    .fragment_fn = "cell_bg_ps",
+                    .vertex_fn = "vs_main",
+                    .fragment_fn = "ps_main",
                 }),
                 .cell_text = try Pipeline.init(CellText, .{
-                    .vertex_fn = "cell_text_vs",
-                    .fragment_fn = "cell_text_ps",
+                    .vertex_fn = "vs_main",
+                    .fragment_fn = "ps_main",
                     .step_fn = .per_instance,
                 }),
                 .image = try Pipeline.init(Image, .{
-                    .vertex_fn = "image_vs",
-                    .fragment_fn = "image_ps",
+                    .vertex_fn = "vs_main",
+                    .fragment_fn = "ps_main",
                     .step_fn = .per_instance,
                 }),
                 .bg_image = try Pipeline.init(BgImage, .{
-                    .vertex_fn = "bg_image_vs",
-                    .fragment_fn = "bg_image_ps",
+                    .vertex_fn = "vs_main",
+                    .fragment_fn = "ps_main",
                     .step_fn = .per_instance,
                 }),
             },
             .post_pipelines = &.{},
         };
+    }
+
+    /// Compile all HLSL shaders on the D3D11 device.
+    /// Called once when the device is available.
+    pub fn compileAll(self: *Shaders, device: ?*anyopaque) void {
+        self.device = device;
+        self.pipelines.bg_color.createOnDevice(device, hlsl_bg_color, hlsl_bg_color) catch
+            log.err("failed to compile bg_color shader", .{});
+        self.pipelines.cell_bg.createOnDevice(device, hlsl_cell_bg, hlsl_cell_bg) catch
+            log.err("failed to compile cell_bg shader", .{});
+        self.pipelines.cell_text.createOnDevice(device, hlsl_cell_text, hlsl_cell_text) catch
+            log.err("failed to compile cell_text shader", .{});
+        self.pipelines.image.createOnDevice(device, hlsl_image, hlsl_image) catch
+            log.err("failed to compile image shader", .{});
+        self.pipelines.bg_image.createOnDevice(device, hlsl_bg_image, hlsl_bg_image) catch
+            log.err("failed to compile bg_image shader", .{});
     }
 
     pub fn deinit(self: *Shaders, alloc: Allocator) void {
@@ -155,5 +169,6 @@ pub const Shaders = struct {
         self.pipelines.cell_text.deinit();
         self.pipelines.image.deinit();
         self.pipelines.bg_image.deinit();
+        self.defunct = true;
     }
 };

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1826,7 +1826,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         }
 
         fn uploadBackgroundImage(self: *Self) !void {
-            // Make sure our bg image is uploaded if it needs to be.
             if (self.bg_image) |*bg| {
                 if (bg.isUnloading()) {
                     bg.deinit(self.alloc);

--- a/src/renderer/shaders/hlsl/bg_color.hlsl
+++ b/src/renderer/shaders/hlsl/bg_color.hlsl
@@ -1,0 +1,21 @@
+// Background color shader - fills the entire screen with the background color.
+// Pipeline: full screen triangle (no vertex input)
+#include "common.hlsl"
+
+struct VSOutput {
+    float4 position : SV_Position;
+};
+
+VSOutput vs_main(uint vid : SV_VertexID) {
+    VSOutput output;
+    output.position.x = (vid == 2) ? 3.0 : -1.0;
+    output.position.y = (vid == 0) ? -3.0 : 1.0;
+    output.position.z = 1.0;
+    output.position.w = 1.0;
+    return output;
+}
+
+float4 ps_main(VSOutput input) : SV_Target {
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+    return load_color(unpack4u8(bg_color_packed_4u8), use_linear_blending);
+}

--- a/src/renderer/shaders/hlsl/bg_color.hlsl
+++ b/src/renderer/shaders/hlsl/bg_color.hlsl
@@ -15,8 +15,6 @@ VSOutput vs_main(uint vid : SV_VertexID) {
 }
 
 float4 ps_main(VSOutput input) : SV_Target {
-    // TEST: fixed green color to verify shader draws
-    return float4(0.0, 1.0, 0.0, 1.0);
-    //bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
-    //return load_color(unpack4u8(bg_color_packed_4u8), use_linear_blending);
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+    return load_color(unpack4u8(bg_color_packed_4u8), use_linear_blending);
 }

--- a/src/renderer/shaders/hlsl/bg_color.hlsl
+++ b/src/renderer/shaders/hlsl/bg_color.hlsl
@@ -15,6 +15,8 @@ VSOutput vs_main(uint vid : SV_VertexID) {
 }
 
 float4 ps_main(VSOutput input) : SV_Target {
-    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
-    return load_color(unpack4u8(bg_color_packed_4u8), use_linear_blending);
+    // TEST: fixed green color to verify shader draws
+    return float4(0.0, 1.0, 0.0, 1.0);
+    //bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+    //return load_color(unpack4u8(bg_color_packed_4u8), use_linear_blending);
 }

--- a/src/renderer/shaders/hlsl/bg_color.hlsl
+++ b/src/renderer/shaders/hlsl/bg_color.hlsl
@@ -1,6 +1,5 @@
 // Background color shader - fills the entire screen with the background color.
 // Pipeline: full screen triangle (no vertex input)
-#include "common.hlsl"
 
 struct VSOutput {
     float4 position : SV_Position;

--- a/src/renderer/shaders/hlsl/bg_image.hlsl
+++ b/src/renderer/shaders/hlsl/bg_image.hlsl
@@ -1,0 +1,125 @@
+// Background image shader - renders a background image behind the terminal.
+// Pipeline: full screen triangle with image texture
+#include "common.hlsl"
+
+Texture2D image_tex : register(t0);
+SamplerState image_sampler : register(s0);
+
+static const uint BG_IMAGE_POSITION = 15u;
+static const uint BG_IMAGE_TL = 0u;
+static const uint BG_IMAGE_TC = 1u;
+static const uint BG_IMAGE_TR = 2u;
+static const uint BG_IMAGE_ML = 3u;
+static const uint BG_IMAGE_MC = 4u;
+static const uint BG_IMAGE_MR = 5u;
+static const uint BG_IMAGE_BL = 6u;
+static const uint BG_IMAGE_BC = 7u;
+static const uint BG_IMAGE_BR = 8u;
+static const uint BG_IMAGE_FIT = 3u << 4;
+static const uint BG_IMAGE_CONTAIN = 0u << 4;
+static const uint BG_IMAGE_COVER = 1u << 4;
+static const uint BG_IMAGE_STRETCH = 2u << 4;
+static const uint BG_IMAGE_NO_FIT = 3u << 4;
+static const uint BG_IMAGE_REPEAT = 1u << 6;
+
+struct VSInput {
+    float opacity : OPACITY;
+    uint info : INFO;
+    uint vid : SV_VertexID;
+};
+
+struct PSInput {
+    float4 position : SV_Position;
+    nointerpolation float4 bg_color : BG_COLOR;
+    nointerpolation float2 offset : OFFSET;
+    nointerpolation float2 scale : SCALE;
+    nointerpolation float opacity : OPACITY;
+    nointerpolation uint repeat_flag : REPEAT;
+};
+
+PSInput vs_main(VSInput input) {
+    PSInput output;
+
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+
+    output.position.x = (input.vid == 2) ? 3.0 : -1.0;
+    output.position.y = (input.vid == 0) ? -3.0 : 1.0;
+    output.position.z = 1.0;
+    output.position.w = 1.0;
+
+    output.opacity = input.opacity;
+    output.repeat_flag = input.info & BG_IMAGE_REPEAT;
+
+    float2 scr = screen_size;
+    float2 tex_size;
+    image_tex.GetDimensions(tex_size.x, tex_size.y);
+
+    float2 dest_size = tex_size;
+    uint fit = input.info & BG_IMAGE_FIT;
+    if (fit == BG_IMAGE_CONTAIN) {
+        float s = min(scr.x / tex_size.x, scr.y / tex_size.y);
+        dest_size = tex_size * s;
+    } else if (fit == BG_IMAGE_COVER) {
+        float s = max(scr.x / tex_size.x, scr.y / tex_size.y);
+        dest_size = tex_size * s;
+    } else if (fit == BG_IMAGE_STRETCH) {
+        dest_size = scr;
+    }
+
+    float2 start = float2(0, 0);
+    float2 mid = (scr - dest_size) / 2.0;
+    float2 end_pos = scr - dest_size;
+
+    float2 dest_offset = mid;
+    uint pos = input.info & BG_IMAGE_POSITION;
+    if (pos == BG_IMAGE_TL) dest_offset = float2(start.x, start.y);
+    else if (pos == BG_IMAGE_TC) dest_offset = float2(mid.x, start.y);
+    else if (pos == BG_IMAGE_TR) dest_offset = float2(end_pos.x, start.y);
+    else if (pos == BG_IMAGE_ML) dest_offset = float2(start.x, mid.y);
+    else if (pos == BG_IMAGE_MC) dest_offset = float2(mid.x, mid.y);
+    else if (pos == BG_IMAGE_MR) dest_offset = float2(end_pos.x, mid.y);
+    else if (pos == BG_IMAGE_BL) dest_offset = float2(start.x, end_pos.y);
+    else if (pos == BG_IMAGE_BC) dest_offset = float2(mid.x, end_pos.y);
+    else if (pos == BG_IMAGE_BR) dest_offset = float2(end_pos.x, end_pos.y);
+
+    output.offset = dest_offset;
+    output.scale = tex_size / dest_size;
+
+    uint4 u_bg = unpack4u8(bg_color_packed_4u8);
+    output.bg_color = float4(
+        load_color(uint4(u_bg.rgb, 255), use_linear_blending).rgb,
+        (float)u_bg.a / 255.0
+    );
+
+    return output;
+}
+
+float4 ps_main(PSInput input) : SV_Target {
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+
+    float2 tex_coord = (input.position.xy - input.offset) * input.scale;
+
+    float2 tex_size;
+    image_tex.GetDimensions(tex_size.x, tex_size.y);
+
+    if (input.repeat_flag != 0) {
+        tex_coord = fmod(fmod(tex_coord, tex_size) + tex_size, tex_size);
+    }
+
+    float4 rgba;
+    if (any(tex_coord < float2(0, 0)) || any(tex_coord > tex_size)) {
+        rgba = float4(0, 0, 0, 0);
+    } else {
+        rgba = image_tex.Sample(image_sampler, tex_coord / tex_size);
+        if (!use_linear_blending) {
+            rgba = unlinearize4(rgba);
+        }
+        rgba.rgb *= rgba.a;
+    }
+
+    rgba *= min(input.opacity, 1.0 / input.bg_color.a);
+    rgba += max(float4(0, 0, 0, 0), float4(input.bg_color.rgb, 1.0) * float4(1.0 - rgba.a, 1.0 - rgba.a, 1.0 - rgba.a, 1.0 - rgba.a));
+    rgba *= input.bg_color.a;
+
+    return rgba;
+}

--- a/src/renderer/shaders/hlsl/bg_image.hlsl
+++ b/src/renderer/shaders/hlsl/bg_image.hlsl
@@ -1,6 +1,5 @@
 // Background image shader - renders a background image behind the terminal.
 // Pipeline: full screen triangle with image texture
-#include "common.hlsl"
 
 Texture2D image_tex : register(t0);
 SamplerState image_sampler : register(s0);

--- a/src/renderer/shaders/hlsl/bg_image.hlsl
+++ b/src/renderer/shaders/hlsl/bg_image.hlsl
@@ -94,35 +94,29 @@ PSInput vs_main(VSInput input) {
 }
 
 float4 ps_main(PSInput input) : SV_Target {
-    // Background image: stretch to fill with opacity
-    // TODO: implement proper cover/contain/position modes
-    float4 img = image_tex.Sample(image_sampler, input.position.xy / screen_size);
-    return float4(img.rgb * 0.3, 1.0);
-    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+    // Get texture dimensions
+    uint tex_w, tex_h;
+    image_tex.GetDimensions(tex_w, tex_h);
+    float2 tex_size = float2(tex_w, tex_h);
+    // Fallback if GetDimensions fails
+    if (tex_w == 0 || tex_h == 0) tex_size = screen_size;
+    float op = input.opacity;
 
-    float2 tex_coord = (input.position.xy - input.offset) * input.scale;
+    uint4 bg_u = unpack4u8(bg_color_packed_4u8);
+    float3 bg = float3(bg_u.rgb) / 255.0;
+    float bg_a = (float)bg_u.a / 255.0;
 
-    float2 tex_size;
-    image_tex.GetDimensions(tex_size.x, tex_size.y);
+    // Cover: scale to fill, center
+    float s = max(screen_size.x / tex_size.x, screen_size.y / tex_size.y);
+    float2 scaled = tex_size * s;
+    float2 ofs = (screen_size - scaled) * 0.5;
+    float2 uv = (input.position.xy - ofs) / scaled;
 
-    if (input.repeat_flag != 0) {
-        tex_coord = fmod(fmod(tex_coord, tex_size) + tex_size, tex_size);
+    float4 img = float4(0, 0, 0, 0);
+    if (uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0) {
+        img = image_tex.Sample(image_sampler, uv);
     }
 
-    float4 rgba;
-    if (any(tex_coord < float2(0, 0)) || any(tex_coord > tex_size)) {
-        rgba = float4(0, 0, 0, 0);
-    } else {
-        rgba = image_tex.Sample(image_sampler, tex_coord / tex_size);
-        if (!use_linear_blending) {
-            rgba = unlinearize4(rgba);
-        }
-        rgba.rgb *= rgba.a;
-    }
-
-    rgba *= min(input.opacity, 1.0 / input.bg_color.a);
-    rgba += max(float4(0, 0, 0, 0), float4(input.bg_color.rgb, 1.0) * float4(1.0 - rgba.a, 1.0 - rgba.a, 1.0 - rgba.a, 1.0 - rgba.a));
-    rgba *= input.bg_color.a;
-
-    return rgba;
+    float3 blended = lerp(bg, img.rgb, img.a * op);
+    return float4(blended * bg_a, bg_a);
 }

--- a/src/renderer/shaders/hlsl/bg_image.hlsl
+++ b/src/renderer/shaders/hlsl/bg_image.hlsl
@@ -94,6 +94,10 @@ PSInput vs_main(VSInput input) {
 }
 
 float4 ps_main(PSInput input) : SV_Target {
+    // Background image: stretch to fill with opacity
+    // TODO: implement proper cover/contain/position modes
+    float4 img = image_tex.Sample(image_sampler, input.position.xy / screen_size);
+    return float4(img.rgb * 0.3, 1.0);
     bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
 
     float2 tex_coord = (input.position.xy - input.offset) * input.scale;

--- a/src/renderer/shaders/hlsl/cell_bg.hlsl
+++ b/src/renderer/shaders/hlsl/cell_bg.hlsl
@@ -48,5 +48,5 @@ float4 ps_main(VSOutput input) : SV_Target {
         use_linear_blending
     );
 
-    return cell_color;
+    return float4(1.0, 0.0, 1.0, 1.0); // TEST magenta
 }

--- a/src/renderer/shaders/hlsl/cell_bg.hlsl
+++ b/src/renderer/shaders/hlsl/cell_bg.hlsl
@@ -1,7 +1,7 @@
 // Cell background shader - renders per-cell background colors.
 // Pipeline: full screen triangle + structured buffer for cell colors
 
-StructuredBuffer<uint> bg_cells : register(t1);
+Buffer<uint> bg_cells : register(t1);
 
 struct VSOutput {
     float4 position : SV_Position;

--- a/src/renderer/shaders/hlsl/cell_bg.hlsl
+++ b/src/renderer/shaders/hlsl/cell_bg.hlsl
@@ -1,0 +1,53 @@
+// Cell background shader - renders per-cell background colors.
+// Pipeline: full screen triangle + structured buffer for cell colors
+#include "common.hlsl"
+
+StructuredBuffer<uint> bg_cells : register(t1);
+
+struct VSOutput {
+    float4 position : SV_Position;
+};
+
+VSOutput vs_main(uint vid : SV_VertexID) {
+    VSOutput output;
+    output.position.x = (vid == 2) ? 3.0 : -1.0;
+    output.position.y = (vid == 0) ? -3.0 : 1.0;
+    output.position.z = 1.0;
+    output.position.w = 1.0;
+    return output;
+}
+
+float4 ps_main(VSOutput input) : SV_Target {
+    uint2 grid_size = unpack2u16(grid_size_packed_2u16);
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+
+    // FragCoord in D3D11 is already upper-left origin
+    int2 grid_pos = int2(floor((input.position.xy - grid_padding.wx) / cell_size));
+
+    float4 bg = float4(0, 0, 0, 0);
+
+    // Clamp x position
+    if (grid_pos.x < 0) {
+        if ((padding_extend & EXTEND_LEFT) != 0) grid_pos.x = 0;
+        else return bg;
+    } else if (grid_pos.x > (int)grid_size.x - 1) {
+        if ((padding_extend & EXTEND_RIGHT) != 0) grid_pos.x = (int)grid_size.x - 1;
+        else return bg;
+    }
+
+    // Clamp y position
+    if (grid_pos.y < 0) {
+        if ((padding_extend & EXTEND_UP) != 0) grid_pos.y = 0;
+        else return bg;
+    } else if (grid_pos.y > (int)grid_size.y - 1) {
+        if ((padding_extend & EXTEND_DOWN) != 0) grid_pos.y = (int)grid_size.y - 1;
+        else return bg;
+    }
+
+    float4 cell_color = load_color(
+        unpack4u8(bg_cells[grid_pos.y * grid_size.x + grid_pos.x]),
+        use_linear_blending
+    );
+
+    return cell_color;
+}

--- a/src/renderer/shaders/hlsl/cell_bg.hlsl
+++ b/src/renderer/shaders/hlsl/cell_bg.hlsl
@@ -1,6 +1,5 @@
 // Cell background shader - renders per-cell background colors.
 // Pipeline: full screen triangle + structured buffer for cell colors
-#include "common.hlsl"
 
 StructuredBuffer<uint> bg_cells : register(t1);
 

--- a/src/renderer/shaders/hlsl/cell_bg.hlsl
+++ b/src/renderer/shaders/hlsl/cell_bg.hlsl
@@ -48,5 +48,5 @@ float4 ps_main(VSOutput input) : SV_Target {
         use_linear_blending
     );
 
-    return float4(1.0, 0.0, 1.0, 1.0); // TEST magenta
+    return cell_color;
 }

--- a/src/renderer/shaders/hlsl/cell_text.hlsl
+++ b/src/renderer/shaders/hlsl/cell_text.hlsl
@@ -5,7 +5,7 @@ Texture2D atlas_grayscale : register(t0);
 Texture2D atlas_color : register(t1);
 SamplerState atlas_sampler : register(s0);
 
-StructuredBuffer<uint> bg_colors : register(t2);
+Buffer<uint> bg_colors : register(t2);
 
 static const uint ATLAS_GRAYSCALE = 0u;
 static const uint ATLAS_COLOR = 1u;

--- a/src/renderer/shaders/hlsl/cell_text.hlsl
+++ b/src/renderer/shaders/hlsl/cell_text.hlsl
@@ -28,6 +28,7 @@ struct PSInput {
     nointerpolation uint atlas : ATLAS;
     nointerpolation float4 color : COLOR;
     nointerpolation float4 bg_color : BG_COLOR;
+    nointerpolation uint is_cursor : IS_CURSOR;
     float2 tex_coord : TEXCOORD;
 };
 
@@ -74,6 +75,8 @@ PSInput vs_main(VSInput input) {
     if ((input.glyph_bools & IS_CURSOR_GLYPH) == 0 && is_cursor_pos) {
         output.color = load_color(unpack4u8(cursor_color_packed_4u8), use_linear_blending);
     }
+
+    output.is_cursor = (input.glyph_bools & IS_CURSOR_GLYPH);
 
     return output;
 }

--- a/src/renderer/shaders/hlsl/cell_text.hlsl
+++ b/src/renderer/shaders/hlsl/cell_text.hlsl
@@ -28,7 +28,6 @@ struct PSInput {
     nointerpolation uint atlas : ATLAS;
     nointerpolation float4 color : COLOR;
     nointerpolation float4 bg_color : BG_COLOR;
-    nointerpolation uint is_cursor : IS_CURSOR;
     float2 tex_coord : TEXCOORD;
 };
 
@@ -75,8 +74,6 @@ PSInput vs_main(VSInput input) {
     if ((input.glyph_bools & IS_CURSOR_GLYPH) == 0 && is_cursor_pos) {
         output.color = load_color(unpack4u8(cursor_color_packed_4u8), use_linear_blending);
     }
-
-    output.is_cursor = (input.glyph_bools & IS_CURSOR_GLYPH);
 
     return output;
 }

--- a/src/renderer/shaders/hlsl/cell_text.hlsl
+++ b/src/renderer/shaders/hlsl/cell_text.hlsl
@@ -1,0 +1,122 @@
+// Cell text shader - renders text glyphs from font atlas.
+// Pipeline: instanced quad rendering with per-instance glyph data
+#include "common.hlsl"
+
+Texture2D atlas_grayscale : register(t0);
+Texture2D atlas_color : register(t1);
+SamplerState atlas_sampler : register(s0);
+
+StructuredBuffer<uint> bg_colors : register(t2);
+
+static const uint ATLAS_GRAYSCALE = 0u;
+static const uint ATLAS_COLOR = 1u;
+static const uint NO_MIN_CONTRAST = 1u;
+static const uint IS_CURSOR_GLYPH = 2u;
+
+struct VSInput {
+    uint2 glyph_pos : GLYPH_POS;
+    uint2 glyph_size : GLYPH_SIZE;
+    int2 bearings : BEARINGS;
+    uint2 grid_pos : GRID_POS;
+    uint4 color : COLOR;
+    uint atlas : ATLAS;
+    uint glyph_bools : GLYPH_BOOLS;
+    uint vid : SV_VertexID;
+};
+
+struct PSInput {
+    float4 position : SV_Position;
+    nointerpolation uint atlas : ATLAS;
+    nointerpolation float4 color : COLOR;
+    nointerpolation float4 bg_color : BG_COLOR;
+    float2 tex_coord : TEXCOORD;
+};
+
+PSInput vs_main(VSInput input) {
+    PSInput output;
+
+    uint2 grid_size = unpack2u16(grid_size_packed_2u16);
+    uint2 cursor_pos = unpack2u16(cursor_pos_packed_2u16);
+    bool cursor_wide = (bools & CURSOR_WIDE) != 0;
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+
+    float2 cell_pos = cell_size * float2(input.grid_pos);
+
+    int vid = input.vid;
+    float2 corner;
+    corner.x = (float)(vid == 1 || vid == 3);
+    corner.y = (float)(vid == 2 || vid == 3);
+
+    output.atlas = input.atlas;
+
+    float2 size = float2(input.glyph_size);
+    float2 offset = float2(input.bearings);
+    offset.y = cell_size.y - offset.y;
+
+    cell_pos = cell_pos + size * corner + offset;
+    output.position = mul(projection_matrix, float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f));
+
+    // Texture coordinate in pixels (not normalized)
+    output.tex_coord = float2(input.glyph_pos) + float2(input.glyph_size) * corner;
+
+    output.color = load_color(input.color, true);
+    output.bg_color = load_color(
+        unpack4u8(bg_colors[input.grid_pos.y * grid_size.x + input.grid_pos.x]),
+        true
+    );
+    float4 global_bg = load_color(unpack4u8(bg_color_packed_4u8), true);
+    output.bg_color += global_bg * float4(1.0 - output.bg_color.a, 1.0 - output.bg_color.a, 1.0 - output.bg_color.a, 1.0 - output.bg_color.a);
+
+    if (min_contrast > 1.0f && (input.glyph_bools & NO_MIN_CONTRAST) == 0) {
+        output.color = contrasted_color(min_contrast, output.color, output.bg_color);
+    }
+
+    bool is_cursor_pos = ((input.grid_pos.x == cursor_pos.x) || (cursor_wide && (input.grid_pos.x == (cursor_pos.x + 1)))) && (input.grid_pos.y == cursor_pos.y);
+    if ((input.glyph_bools & IS_CURSOR_GLYPH) == 0 && is_cursor_pos) {
+        output.color = load_color(unpack4u8(cursor_color_packed_4u8), use_linear_blending);
+    }
+
+    return output;
+}
+
+float4 ps_main(PSInput input) : SV_Target {
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+    bool use_linear_correction = (bools & USE_LINEAR_CORRECTION) != 0;
+
+    // Normalize texture coordinates for sampler2D
+    float2 atlas_size_gs = float2(0, 0);
+    float2 atlas_size_col = float2(0, 0);
+    atlas_grayscale.GetDimensions(atlas_size_gs.x, atlas_size_gs.y);
+    atlas_color.GetDimensions(atlas_size_col.x, atlas_size_col.y);
+
+    if (input.atlas == ATLAS_GRAYSCALE) {
+        float4 color = input.color;
+        if (!use_linear_blending) {
+            color.rgb /= float3(color.a, color.a, color.a);
+            color = unlinearize4(color);
+            color.rgb *= float3(color.a, color.a, color.a);
+        }
+
+        float a = atlas_grayscale.Sample(atlas_sampler, input.tex_coord / atlas_size_gs).r;
+
+        if (use_linear_correction) {
+            float4 bg = input.bg_color;
+            float fg_l = luminance(color.rgb);
+            float bg_l = luminance(bg.rgb);
+            if (abs(fg_l - bg_l) > 0.001) {
+                float blend_l = linearize1(unlinearize1(fg_l) * a + unlinearize1(bg_l) * (1.0 - a));
+                a = clamp((blend_l - bg_l) / (fg_l - bg_l), 0.0, 1.0);
+            }
+        }
+
+        color *= a;
+        return color;
+    } else {
+        float4 color = atlas_color.Sample(atlas_sampler, input.tex_coord / atlas_size_col);
+        if (use_linear_blending) return color;
+        color.rgb /= float3(color.a, color.a, color.a);
+        color = unlinearize4(color);
+        color.rgb *= float3(color.a, color.a, color.a);
+        return color;
+    }
+}

--- a/src/renderer/shaders/hlsl/cell_text.hlsl
+++ b/src/renderer/shaders/hlsl/cell_text.hlsl
@@ -1,6 +1,5 @@
 // Cell text shader - renders text glyphs from font atlas.
 // Pipeline: instanced quad rendering with per-instance glyph data
-#include "common.hlsl"
 
 Texture2D atlas_grayscale : register(t0);
 Texture2D atlas_color : register(t1);

--- a/src/renderer/shaders/hlsl/common.hlsl
+++ b/src/renderer/shaders/hlsl/common.hlsl
@@ -106,9 +106,9 @@ float unlinearize1(float v) {
     return v <= 0.0031308 ? v * 12.92 : pow(v, 1.0 / 2.4) * 1.055 - 0.055;
 }
 
-float4 load_color(uint4 in_color, bool linear) {
+float4 load_color(uint4 in_color, bool do_linearize) {
     float4 color = float4(in_color) / float4(255.0f, 255.0f, 255.0f, 255.0f);
-    if (linear) color = linearize4(color);
+    if (do_linearize) color = linearize4(color);
     color.rgb *= color.a;
     return color;
 }

--- a/src/renderer/shaders/hlsl/common.hlsl
+++ b/src/renderer/shaders/hlsl/common.hlsl
@@ -1,0 +1,114 @@
+// Common definitions shared across all HLSL shaders.
+// Equivalent to common.glsl.
+
+//----------------------------------------------------------------------------//
+// Global Constant Buffer (matches Uniforms struct in shaders.zig)
+//----------------------------------------------------------------------------//
+cbuffer Globals : register(b1) {
+    float4x4 projection_matrix;
+    float2 screen_size;
+    float2 cell_size;
+    uint grid_size_packed_2u16;
+    float4 grid_padding;
+    uint padding_extend;
+    float min_contrast;
+    uint cursor_pos_packed_2u16;
+    uint cursor_color_packed_4u8;
+    uint bg_color_packed_4u8;
+    uint bools;
+};
+
+// Bool flags
+static const uint CURSOR_WIDE = 1u;
+static const uint USE_DISPLAY_P3 = 2u;
+static const uint USE_LINEAR_BLENDING = 4u;
+static const uint USE_LINEAR_CORRECTION = 8u;
+
+// Padding extend flags
+static const uint EXTEND_LEFT = 1u;
+static const uint EXTEND_RIGHT = 2u;
+static const uint EXTEND_UP = 4u;
+static const uint EXTEND_DOWN = 8u;
+
+//----------------------------------------------------------------------------//
+// Unpacking Functions
+//----------------------------------------------------------------------------//
+
+uint4 unpack4u8(uint packed_value) {
+    return uint4(
+        (packed_value >> 0) & 0xFF,
+        (packed_value >> 8) & 0xFF,
+        (packed_value >> 16) & 0xFF,
+        (packed_value >> 24) & 0xFF
+    );
+}
+
+uint2 unpack2u16(uint packed_value) {
+    return uint2(
+        (packed_value >> 0) & 0xFFFF,
+        (packed_value >> 16) & 0xFFFF
+    );
+}
+
+int2 unpack2i16(int packed_value) {
+    return int2(
+        (packed_value << 16) >> 16,
+        (packed_value << 0) >> 16
+    );
+}
+
+//----------------------------------------------------------------------------//
+// Color Functions
+//----------------------------------------------------------------------------//
+
+float luminance(float3 color) {
+    return dot(color, float3(0.2126f, 0.7152f, 0.0722f));
+}
+
+float contrast_ratio(float3 color1, float3 color2) {
+    float luminance1 = luminance(color1) + 0.05;
+    float luminance2 = luminance(color2) + 0.05;
+    return max(luminance1, luminance2) / min(luminance1, luminance2);
+}
+
+float4 contrasted_color(float min_ratio, float4 fg, float4 bg) {
+    float ratio = contrast_ratio(fg.rgb, bg.rgb);
+    if (ratio < min_ratio) {
+        float white_ratio = contrast_ratio(float3(1, 1, 1), bg.rgb);
+        float black_ratio = contrast_ratio(float3(0, 0, 0), bg.rgb);
+        if (white_ratio > black_ratio)
+            return float4(1, 1, 1, 1);
+        else
+            return float4(0, 0, 0, 1);
+    }
+    return fg;
+}
+
+float4 linearize4(float4 srgb) {
+    bool3 cutoff = (srgb.rgb <= float3(0.04045, 0.04045, 0.04045));
+    float3 higher = pow((srgb.rgb + float3(0.055, 0.055, 0.055)) / float3(1.055, 1.055, 1.055), float3(2.4, 2.4, 2.4));
+    float3 lower = srgb.rgb / float3(12.92, 12.92, 12.92);
+    return float4(cutoff ? lower : higher, srgb.a);
+}
+
+float linearize1(float v) {
+    return v <= 0.04045 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4);
+}
+
+float4 unlinearize4(float4 lin) {
+    bool3 cutoff = (lin.rgb <= float3(0.0031308, 0.0031308, 0.0031308));
+    float3 higher = pow(lin.rgb, float3(1.0 / 2.4, 1.0 / 2.4, 1.0 / 2.4)) * float3(1.055, 1.055, 1.055) - float3(0.055, 0.055, 0.055);
+    float3 lower = lin.rgb * float3(12.92, 12.92, 12.92);
+    return float4(cutoff ? lower : higher, lin.a);
+}
+
+float unlinearize1(float v) {
+    return v <= 0.0031308 ? v * 12.92 : pow(v, 1.0 / 2.4) * 1.055 - 0.055;
+}
+
+float4 load_color(uint4 in_color, bool linear) {
+    float4 color = float4(in_color) / float4(255.0f, 255.0f, 255.0f, 255.0f);
+    if (linear) color = linearize4(color);
+    color.rgb *= color.a;
+    return color;
+}

--- a/src/renderer/shaders/hlsl/image.hlsl
+++ b/src/renderer/shaders/hlsl/image.hlsl
@@ -1,0 +1,56 @@
+// Image shader - renders embedded images (kitty image protocol, etc.)
+// Pipeline: instanced quad rendering
+#include "common.hlsl"
+
+Texture2D image_tex : register(t0);
+SamplerState image_sampler : register(s0);
+
+struct VSInput {
+    float2 grid_pos : GRID_POS;
+    float2 cell_offset : CELL_OFFSET;
+    float4 source_rect : SOURCE_RECT;
+    float2 dest_size : DEST_SIZE;
+    uint vid : SV_VertexID;
+};
+
+struct PSInput {
+    float4 position : SV_Position;
+    float2 tex_coord : TEXCOORD;
+};
+
+PSInput vs_main(VSInput input) {
+    PSInput output;
+
+    int vid = input.vid;
+    float2 corner;
+    corner.x = (float)(vid == 1 || vid == 3);
+    corner.y = (float)(vid == 2 || vid == 3);
+
+    // Texture coordinates from source rect
+    output.tex_coord = input.source_rect.xy + input.source_rect.zw * corner;
+
+    // Normalize
+    float2 tex_size;
+    image_tex.GetDimensions(tex_size.x, tex_size.y);
+    output.tex_coord /= tex_size;
+
+    // Position
+    float2 image_pos = (cell_size * input.grid_pos) + input.cell_offset;
+    image_pos += input.dest_size * corner;
+    output.position = mul(projection_matrix, float4(image_pos.xy, 1.0, 1.0));
+
+    return output;
+}
+
+float4 ps_main(PSInput input) : SV_Target {
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+
+    float4 rgba = image_tex.Sample(image_sampler, input.tex_coord);
+
+    if (!use_linear_blending) {
+        rgba = unlinearize4(rgba);
+    }
+
+    rgba.rgb *= float3(rgba.a, rgba.a, rgba.a);
+    return rgba;
+}

--- a/src/renderer/shaders/hlsl/image.hlsl
+++ b/src/renderer/shaders/hlsl/image.hlsl
@@ -1,6 +1,5 @@
 // Image shader - renders embedded images (kitty image protocol, etc.)
 // Pipeline: instanced quad rendering
-#include "common.hlsl"
 
 Texture2D image_tex : register(t0);
 SamplerState image_sampler : register(s0);


### PR DESCRIPTION
## Summary / 概要

Native DirectX 11 renderer backend for Ghostty on Windows, replacing the Mesa Zink (OpenGL→Vulkan) translation layer to reduce input latency.

<details><summary>日本語</summary>

Windows上のGhosttyにネイティブDirectX 11レンダラーバックエンドを追加。入力遅延削減のためMesa Zink（OpenGL→Vulkan）変換レイヤーを置き換える。

</details>

## Architecture / アーキテクチャ

- **D3D11 C wrapper** (\`d3d11_impl.c\`): Flat C API over COM-based D3D11 for Zig consumption
- **HLSL shaders**: 5 shader pairs (bg_color, cell_bg, cell_text, image, bg_image) translated from GLSL
- **Pipeline**: Lazy compilation — HLSL stored at comptime, compiled on renderer thread
- **Native render loop**: Bypasses xev IOCP (incompatible with D3D11), uses \`while + Sleep(4)\` at ~240fps
- **Pluggable**: \`-Drenderer=directx\` build flag, zero impact on OpenGL/Metal builds

<details><summary>日本語</summary>

- **D3D11 Cラッパー**（\`d3d11_impl.c\`）: COM基盤のD3D11をZigから使うためのフラットC API
- **HLSLシェーダー**: GLSLから変換した5組のシェーダーペア（bg_color, cell_bg, cell_text, image, bg_image）
- **パイプライン**: 遅延コンパイル — HLSLをcomptimeで格納し、レンダラースレッドでコンパイル
- **ネイティブレンダーループ**: xev IOCP（D3D11と非互換）をバイパスし、\`while + Sleep(4)\`で約240fps
- **プラグイン式**: \`-Drenderer=directx\`ビルドフラグ、OpenGL/Metalビルドへの影響ゼロ

</details>

## Features Working / 動作する機能

- ✅ Terminal text rendering (font atlas + instanced draw)
- ✅ Cell background colors
- ✅ Cursor display and blinking
- ✅ Text input (keyboard echo)
- ✅ Window resize with swap chain resize
- ✅ Background image (cover mode + opacity + bg_color blend)
- ✅ Scroll
- ✅ Alt+F4 window close
- ✅ Adaptive framerate (240fps focused, 60fps unfocused)

<details><summary>日本語</summary>

- ✅ ターミナルテキスト描画（フォントアトラス＋インスタンス描画）
- ✅ セル背景色
- ✅ カーソル表示と点滅
- ✅ テキスト入力（キーボードエコー）
- ✅ ウィンドウリサイズ（スワップチェインリサイズ付き）
- ✅ 背景画像（coverモード＋透明度＋背景色ブレンド）
- ✅ スクロール
- ✅ Alt+F4ウィンドウ閉じ
- ✅ 適応フレームレート（フォーカス時240fps、非フォーカス時60fps）

</details>

## Key Technical Decisions / 主要な技術的決定

### Native render loop instead of xev / xevの代わりにネイティブレンダーループ

xev's IOCP-based event loop stops responding after D3D11 device creation on the renderer thread. Async notifications and timer callbacks never fire. Solved with a native Windows \`while + Sleep\` loop. See #7 for details.

<details><summary>日本語</summary>

xevのIOCPベースのイベントループはレンダラースレッドでD3D11デバイス作成後に応答しなくなる。非同期通知とタイマーコールバックが発火しない。ネイティブWindows \`while + Sleep\`ループで解決。詳細は #7 参照。

</details>

### Global device handle / グローバルデバイスハンドル

\`current_device\` global instead of \`self.device\` — the DirectX struct is stored by value in GenericRenderer and copied, losing the device field. Global ensures all code paths access the same device.

<details><summary>日本語</summary>

\`self.device\`の代わりに\`current_device\`グローバル — DirectX構造体はGenericRendererに値で格納されコピーされるため、deviceフィールドが失われる。グローバルで全コードパスが同じデバイスにアクセスすることを保証。

</details>

### Atomic window size notification / アトミックウィンドウサイズ通知

\`GetClientRect\` blocks when called from the renderer thread (Win32 cross-thread GUI sync). Solved with \`dx_notify_resize\` export: C++ WM_SIZE → atomic globals → renderer reads in \`surfaceSize()\`.

<details><summary>日本語</summary>

\`GetClientRect\`はレンダラースレッドから呼ぶとブロック（Win32クロススレッドGUI同期）。\`dx_notify_resize\`エクスポートで解決: C++ WM_SIZE → atomicグローバル → レンダラーが\`surfaceSize()\`で読み取り。

</details>

### Frame completion / フレーム完了

\`Frame.complete()\` must call \`self.renderer.frameCompleted(.healthy)\` to release the swap chain semaphore. Without this, rendering deadlocks after \`swap_chain_count\` frames. See #7 for the full investigation.

<details><summary>日本語</summary>

\`Frame.complete()\`は\`self.renderer.frameCompleted(.healthy)\`を呼んでスワップチェインセマフォを解放する必要がある。これがないと\`swap_chain_count\`フレーム後にデッドロック。完全な調査は #7 参照。

</details>

## Files Changed / 変更ファイル

### New files / 新規ファイル
- \`src/renderer/DirectX.zig\` — Main DirectX 11 graphics API wrapper
- \`src/renderer/directx/\` — Frame, Pipeline, RenderPass, Buffer, Texture, Sampler, Target, shaders
- \`src/renderer/directx/d3d11_impl.c\` / \`.h\` — D3D11 COM wrapper in C
- \`src/renderer/shaders/hlsl/\` — 5 HLSL shader files + common.hlsl

### Modified files / 変更ファイル
- \`src/renderer.zig\` — Added DirectX import and Renderer switch
- \`src/renderer/backend.zig\` — Added \`directx\` to Backend enum
- \`src/renderer/generic.zig\` — No changes (shared code works as-is)
- \`src/renderer/Thread.zig\` — Native render loop for \`native_render_loop = true\`
- \`src/build/SharedDeps.zig\` — Added d3d11_impl.c compilation for Windows

## Known Issues / 既知の問題

- Background image: only cover mode implemented (#9)
- \`background-opacity\`: DWM transparency not fully tested (#8)
- HLSL \`GetDimensions\` float overload returns 0, use uint overload (#11)
- \`surfaceSize\` cannot call \`GetClientRect\` from renderer thread (#12)
- Input latency benchmark vs Mesa Zink not yet measured (#13)

## Related Issues / 関連Issue

- #7 — Frame deadlock (root cause investigation + fix)
- #8 — background-opacity DWM support
- #9 — bg_image fit/position/repeat modes
- #10 — Alt+F4 (fixed)
- #11 — HLSL GetDimensions
- #12 — surfaceSize GetClientRect
- #13 — Input latency benchmark
- #14 — Dynamic renderer switching
- #15 — Event loop abstraction proposal