### PR TITLE
DirectX: multi-surface support with DirectComposition

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1592,6 +1592,17 @@ pub const CAPI = struct {
         return surface.userdata;
     }
 
+    /// Returns the DirectX device pointer for per-surface resize notification.
+    /// Returns null on non-DirectX backends.
+    export fn ghostty_surface_dx_device(surface: *Surface) ?*anyopaque {
+        if (comptime @hasField(@TypeOf(surface.core_surface.renderer.api), "device")) {
+            if (surface.core_surface.renderer.api.device) |dev| {
+                return @ptrCast(dev);
+            }
+        }
+        return null;
+    }
+
     /// Returns the app associated with a surface.
     export fn ghostty_surface_app(surface: *Surface) *App {
         return surface.app;

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -29,9 +29,9 @@ pub const custom_shader_y_is_down = true;
 pub const swap_chain_count = 2;
 
 /// Called from C++ WM_SIZE to update window size without cross-thread deadlock.
-/// Thin wrapper needed because Zig DLL only exports Zig `export fn`, not C functions.
-export fn dx_notify_resize(w: u32, h: u32) void {
-    dx.dx_set_window_size(w, h);
+/// Takes the device pointer so each surface's size is tracked independently.
+export fn dx_notify_resize(dev: ?*dx.DxDevice, w: u32, h: u32) void {
+    dx.dx_set_window_size(dev, w, h);
 }
 
 /// Use a native Windows render loop instead of xev.
@@ -40,10 +40,9 @@ pub const native_render_loop = true;
 
 const log = std.log.scoped(.directx);
 
-/// Global device handle, accessible by Buffer/Texture/etc.
-pub var current_device: ?*dx.DxDevice = null;
-/// HWND stored from surfaceInit for device creation in threadEnter.
-pub var stored_hwnd: ?*anyopaque = null;
+/// Per-thread device handle, accessible by Buffer/Texture/etc.
+/// Each renderer thread sets its own copy in threadEnter.
+pub threadlocal var current_device: ?*dx.DxDevice = null;
 
 // C API from d3d11_impl.c — imported via build-system TranslateC for type safety
 pub const dx = @import("d3d11-c");
@@ -63,23 +62,15 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!DirectX {
 
 pub fn deinit(self: *DirectX) void {
     if (self.device) |dev| dx.dx_destroy(dev);
-    current_device = null;
-    stored_hwnd = null;
+    self.device = null;
+    // Note: current_device is threadlocal, only clear if we're on the renderer thread.
+    // It's safe to leave stale — threadEnter sets it on the next surface.
     self.* = undefined;
 }
 
 pub fn surfaceInit(surface: *apprt.Surface) !void {
-    if (comptime builtin.os.tag != .windows) return;
-    const hwnd: ?*anyopaque = @ptrCast(surface.platform.windows.hwnd);
-    stored_hwnd = hwnd;
-
-    // Set initial window size (main thread, safe to call GetClientRect here)
-    var rect: windows.exp.RECT = undefined;
-    _ = windows.exp.user32.GetClientRect(hwnd, &rect);
-    dx.dx_set_window_size(
-        @intCast(@max(rect.right - rect.left, 1)),
-        @intCast(@max(rect.bottom - rect.top, 1)),
-    );
+    _ = surface;
+    // Device creation and initial window size are handled in threadEnter.
 }
 
 pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void {
@@ -88,17 +79,33 @@ pub fn finalizeSurfaceInit(self: *const DirectX, surface: *apprt.Surface) !void 
 }
 
 pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
-    _ = surface;
-    const hwnd = stored_hwnd orelse return;
+    if (comptime builtin.os.tag != .windows) return;
+    const hwnd: ?*anyopaque = @ptrCast(surface.platform.windows.hwnd);
+    if (hwnd == null) {
+        log.err("HWND not set on surface — surfaceInit was not called", .{});
+        return error.HWNDNotSet;
+    }
+
+    // Destroy any existing device first — DXGI flip-model only allows one
+    // swap chain per HWND, so we must tear down the old one before creating
+    // a new one (e.g. if threadEnter is called again after threadExit).
+    const self_mut: *DirectX = @constCast(self);
+    if (self_mut.device) |old| {
+        dx.dx_destroy(old);
+        self_mut.device = null;
+        current_device = null;
+    }
+
     var rect: windows.exp.RECT = undefined;
     _ = windows.exp.user32.GetClientRect(hwnd, &rect);
     const w: u32 = @intCast(@max(rect.right - rect.left, 1));
     const h: u32 = @intCast(@max(rect.bottom - rect.top, 1));
 
     const dev = dx.dx_create(hwnd, w, h) orelse return;
-    const self_mut: *DirectX = @constCast(self);
     self_mut.device = dev;
     current_device = dev;
+    // Set initial window size on the newly created device
+    dx.dx_set_window_size(dev, w, h);
 }
 
 pub fn threadExit(self: *const DirectX) void {
@@ -136,7 +143,7 @@ pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
     // Cannot call GetClientRect from renderer thread (cross-thread deadlock).
     var ww: u32 = 0;
     var wh: u32 = 0;
-    dx.dx_get_window_size(&ww, &wh);
+    dx.dx_get_window_size(dev, &ww, &wh);
     if (ww > 0 and wh > 0) {
         var bbw: u32 = 0;
         var bbh: u32 = 0;

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -34,6 +34,12 @@ export fn dx_notify_resize(dev: ?*dx.DxDevice, w: u32, h: u32) void {
     dx.dx_set_window_size(dev, w, h);
 }
 
+/// Called from C++ to show/hide a surface's DirectComposition visual (tab switching).
+/// Safe to call from main thread while the renderer is active on another thread.
+export fn dx_set_surface_visible(dev: ?*dx.DxDevice, visible: bool) void {
+    dx.dx_set_visible(dev, visible);
+}
+
 /// Use a native Windows render loop instead of xev.
 /// xev's IOCP event loop stalls after D3D11 device creation.
 pub const native_render_loop = true;

--- a/src/renderer/directx/Pipeline.zig
+++ b/src/renderer/directx/Pipeline.zig
@@ -25,7 +25,9 @@ layout_type: LayoutType = .none,
 
 const LayoutType = enum { none, cell_text, bg_image, image };
 
-const MAX_PIPELINES = 16;
+// --- Global source registry (comptime HLSL, deduplicated by pointer) ---
+
+const MAX_SOURCES = 16;
 
 const SourceEntry = struct {
     vs: ?[*]const u8 = null,
@@ -34,9 +36,24 @@ const SourceEntry = struct {
     ps_len: u32 = 0,
 };
 
-var sources: [MAX_PIPELINES]SourceEntry = [_]SourceEntry{.{}} ** MAX_PIPELINES;
-var handles: [MAX_PIPELINES]?*dx.DxPipeline = [_]?*dx.DxPipeline{null} ** MAX_PIPELINES;
+var sources: [MAX_SOURCES]SourceEntry = [_]SourceEntry{.{}} ** MAX_SOURCES;
 var next_id: u8 = 1;
+
+// --- Per-device handle cache ---
+// Each source ID can have a compiled pipeline on multiple devices.
+// We store (device, handle) pairs so different surfaces (different devices)
+// each get their own pipeline object without conflicting.
+
+const MAX_DEVICES = 8;
+
+const DeviceHandle = struct {
+    device: ?*dx.DxDevice = null,
+    handle: ?*dx.DxPipeline = null,
+};
+
+var device_handles: [MAX_SOURCES][MAX_DEVICES]DeviceHandle = [_][MAX_DEVICES]DeviceHandle{
+    [_]DeviceHandle{.{}} ** MAX_DEVICES,
+} ** MAX_SOURCES;
 
 pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     const shaders_mod = @import("shaders.zig");
@@ -52,8 +69,16 @@ pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
     };
 }
 
-/// Store HLSL source pointers (comptime data, always valid). No compilation yet.
+/// Register HLSL source. Deduplicates by pointer identity.
 pub fn storeSource(self: *Self, vs_source: []const u8, ps_source: []const u8) void {
+    // Check if already registered (comptime pointers are stable).
+    var i: u8 = 1;
+    while (i < next_id) : (i += 1) {
+        if (sources[i].vs == vs_source.ptr and sources[i].ps == ps_source.ptr) {
+            self.id = i;
+            return;
+        }
+    }
     const id = next_id;
     next_id += 1;
     self.id = id;
@@ -65,16 +90,24 @@ pub fn storeSource(self: *Self, vs_source: []const u8, ps_source: []const u8) vo
     };
 }
 
-/// Get D3D11 pipeline handle. Compiles HLSL + creates shaders on first call (renderer thread).
+/// Get or create pipeline for the given device. Pipelines are cached
+/// per (source_id, device) pair so multiple surfaces work correctly.
 pub fn getHandle(self: Self, device: ?*dx.DxDevice) ?*dx.DxPipeline {
-    if (self.id == 0 or self.id >= MAX_PIPELINES) return null;
-    if (handles[self.id]) |h| return h;
+    if (self.id == 0 or self.id >= MAX_SOURCES) return null;
     if (device == null) return null;
+
+    // Look up existing handle for this device.
+    const slots = &device_handles[self.id];
+    var free_slot: ?usize = null;
+    for (slots, 0..) |*slot, idx| {
+        if (slot.device == device) return slot.handle;
+        if (free_slot == null and slot.device == null) free_slot = idx;
+    }
 
     const src = &sources[self.id];
     if (src.vs == null or src.ps == null) return null;
 
-    // Compile + create entirely on renderer thread
+    // Compile + create on this device.
     const vs = dx.dx_compile_shader(src.vs, src.vs_len, "vs_main", "vs_5_0");
     const ps = dx.dx_compile_shader(src.ps, src.ps_len, "ps_main", "ps_5_0");
     defer dx.dx_free_compiled_shader(vs);
@@ -88,15 +121,22 @@ pub fn getHandle(self: Self, device: ?*dx.DxDevice) ?*dx.DxPipeline {
         .image => dx.dx_create_image_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size),
         .none => dx.dx_create_pipeline(device, vs.bytecode, vs.size, ps.bytecode, ps.size, null, 0),
     };
-    handles[self.id] = h;
+
+    // Cache for this device.
+    if (free_slot) |slot_idx| {
+        slots[slot_idx] = .{ .device = device, .handle = h };
+    }
     return h;
 }
 
 pub fn deinit(self: *const Self) void {
-    if (self.id > 0 and self.id < MAX_PIPELINES) {
-        if (handles[self.id]) |h| {
+    if (self.id == 0 or self.id >= MAX_SOURCES) return;
+    // Destroy all device handles for this source ID.
+    const slots = &device_handles[self.id];
+    for (slots) |*slot| {
+        if (slot.handle) |h| {
             dx.dx_destroy_pipeline(h);
-            handles[self.id] = null;
         }
+        slot.* = .{};
     }
 }

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -16,10 +16,6 @@
 
 #include "d3d11_impl.h"
 
-// Thread-safe window size (set by main thread, read by renderer thread)
-static volatile uint32_t g_window_width = 0;
-static volatile uint32_t g_window_height = 0;
-
 // --- Device ---
 
 struct DxDevice {
@@ -30,10 +26,15 @@ struct DxDevice {
     ID3D11BlendState* blend_on;
     ID3D11BlendState* blend_off;
     ID3D11RasterizerState* rasterizer_state;
+    ID3D11SamplerState* default_sampler;
     D3D_FEATURE_LEVEL feature_level;
     HWND hwnd;
     uint32_t bb_width;
     uint32_t bb_height;
+    // Per-device window size (set by main thread via dx_set_window_size,
+    // read by renderer thread). Volatile for cross-thread visibility.
+    volatile uint32_t window_width;
+    volatile uint32_t window_height;
 };
 
 static void dx_create_backbuffer_rtv(DxDevice* dev) {
@@ -146,14 +147,33 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
         ID3D11DeviceContext_RSSetState(dev->context, dev->rasterizer_state);
     }
 
+    // Create default sampler immediately so it's ready for the first draw
+    {
+        D3D11_SAMPLER_DESC sd = {0};
+        sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sd.MaxLOD = D3D11_FLOAT32_MAX;
+        ID3D11Device_CreateSamplerState(dev->device, &sd, &dev->default_sampler);
+        if (dev->default_sampler) {
+            ID3D11DeviceContext_PSSetSamplers(dev->context, 0, 1, &dev->default_sampler);
+        }
+    }
+
     return dev;
 }
 
-static ID3D11SamplerState* default_sampler = NULL;
-
 void dx_destroy(DxDevice* dev) {
     if (!dev) return;
-    if (default_sampler) { ID3D11SamplerState_Release(default_sampler); default_sampler = NULL; }
+    // ClearState + Flush trigger deferred destruction of DXGI flip-model
+    // swap chains. Without this, creating a new swap chain on the same HWND
+    // will fail with DXGI ERROR #297.
+    if (dev->context) {
+        ID3D11DeviceContext_ClearState(dev->context);
+        ID3D11DeviceContext_Flush(dev->context);
+    }
+    if (dev->default_sampler) ID3D11SamplerState_Release(dev->default_sampler);
     if (dev->rasterizer_state) ID3D11RasterizerState_Release(dev->rasterizer_state);
     if (dev->blend_off) ID3D11BlendState_Release(dev->blend_off);
     if (dev->blend_on) ID3D11BlendState_Release(dev->blend_on);
@@ -225,16 +245,19 @@ void dx_clear_shader_resources(DxDevice* dev) {
 }
 
 void dx_ensure_default_sampler(DxDevice* dev) {
-    if (!dev || default_sampler) return;
-    D3D11_SAMPLER_DESC sd = {0};
-    sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
-    sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-    sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-    sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-    sd.MaxLOD = D3D11_FLOAT32_MAX;
-    ID3D11Device_CreateSamplerState(dev->device, &sd, &default_sampler);
-    if (default_sampler) {
-        ID3D11DeviceContext_PSSetSamplers(dev->context, 0, 1, &default_sampler);
+    if (!dev) return;
+    // Create once per device, but always re-bind — pipeline state changes can unbind it.
+    if (!dev->default_sampler) {
+        D3D11_SAMPLER_DESC sd = {0};
+        sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sd.MaxLOD = D3D11_FLOAT32_MAX;
+        ID3D11Device_CreateSamplerState(dev->device, &sd, &dev->default_sampler);
+    }
+    if (dev->default_sampler) {
+        ID3D11DeviceContext_PSSetSamplers(dev->context, 0, 1, &dev->default_sampler);
     }
 }
 
@@ -453,6 +476,10 @@ void dx_bind_pipeline(DxDevice* dev, DxPipeline* pipe) {
     ID3D11DeviceContext_VSSetShader(dev->context, pipe->vs, NULL, 0);
     ID3D11DeviceContext_PSSetShader(dev->context, pipe->ps, NULL, 0);
     ID3D11DeviceContext_IASetInputLayout(dev->context, pipe->input_layout); // NULL is OK for vertex-less draws
+    // Re-bind default sampler — shader switch can invalidate sampler state
+    if (dev->default_sampler) {
+        ID3D11DeviceContext_PSSetSamplers(dev->context, 0, 1, &dev->default_sampler);
+    }
 }
 
 // --- Render Target ---
@@ -614,13 +641,20 @@ DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode,
 
 // --- Window resize notification ---
 
-void dx_set_window_size(uint32_t width, uint32_t height) {
-    g_window_width = width;
-    g_window_height = height;
+void dx_set_window_size(DxDevice* dev, uint32_t width, uint32_t height) {
+    if (dev) {
+        dev->window_width = width;
+        dev->window_height = height;
+    }
 }
 
-void dx_get_window_size(uint32_t* width, uint32_t* height) {
-    *width = g_window_width;
-    *height = g_window_height;
+void dx_get_window_size(DxDevice* dev, uint32_t* width, uint32_t* height) {
+    if (dev) {
+        *width = dev->window_width;
+        *height = dev->window_height;
+    } else {
+        *width = 0;
+        *height = 0;
+    }
 }
 

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -89,6 +89,11 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     IDXGISwapChain1* swap_chain1 = NULL;
     hr = IDXGIFactory2_CreateSwapChainForHwnd(factory, (IUnknown*)dev->device, dev->hwnd, &scd, NULL, NULL, &swap_chain1);
 
+    // Disable DXGI's automatic Alt+Enter fullscreen handling. The host app
+    // implements fullscreen by toggling Win32 window styles instead, and DXGI
+    // refuses SetFullscreenState on swap chains targeting child windows.
+    IDXGIFactory_MakeWindowAssociation((IDXGIFactory*)factory, dev->hwnd, DXGI_MWA_NO_ALT_ENTER);
+
     IDXGIFactory2_Release(factory);
     IDXGIAdapter_Release(adapter);
     IDXGIDevice_Release(dxgi_device);

--- a/src/renderer/directx/d3d11_impl.c
+++ b/src/renderer/directx/d3d11_impl.c
@@ -9,10 +9,82 @@
 #include <d3dcompiler.h>
 #include <dxgi.h>
 #include <dxgi1_2.h>
-
+// dcomp.h is C++-only; declare the minimal DirectComposition interfaces in C.
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "d3dcompiler.lib")
+#pragma comment(lib, "dcomp.lib")
+
+DEFINE_GUID(IID_IDCompositionDevice,  0xC37EA93A, 0xE7AA, 0x450D, 0xB1, 0x6F, 0x97, 0x46, 0xCB, 0x04, 0x07, 0xF3);
+
+// Minimal IDCompositionVisual vtable (only SetContent + Release needed).
+// Each C++ overload occupies its own vtable slot.
+typedef struct IDCompositionVisual IDCompositionVisual;
+typedef struct IDCompositionVisualVtbl {
+    // IUnknown (slots 0-2)
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(IDCompositionVisual*, REFIID, void**);
+    ULONG   (STDMETHODCALLTYPE *AddRef)(IDCompositionVisual*);
+    ULONG   (STDMETHODCALLTYPE *Release)(IDCompositionVisual*);
+    // SetOffsetX: 2 overloads (animation, float) — slots 3-4
+    void* _SetOffsetX_anim;
+    void* _SetOffsetX_float;
+    // SetOffsetY: 2 overloads — slots 5-6
+    void* _SetOffsetY_anim;
+    void* _SetOffsetY_float;
+    // SetTransform: 2 overloads — slots 7-8
+    void* _SetTransform_obj;
+    void* _SetTransform_matrix;
+    // SetTransformParent — slot 9
+    void* _SetTransformParent;
+    // SetEffect — slot 10
+    void* _SetEffect;
+    // SetBitmapInterpolationMode — slot 11
+    void* _SetBitmapInterpolationMode;
+    // SetBorderMode — slot 12
+    void* _SetBorderMode;
+    // SetClip: 2 overloads — slots 13-14
+    void* _SetClip_obj;
+    void* _SetClip_rect;
+    // SetContent — slot 15
+    HRESULT (STDMETHODCALLTYPE *SetContent)(IDCompositionVisual*, IUnknown*);
+} IDCompositionVisualVtbl;
+struct IDCompositionVisual { IDCompositionVisualVtbl* lpVtbl; };
+
+// Minimal IDCompositionTarget vtable (only SetRoot + Release needed)
+typedef struct IDCompositionTarget IDCompositionTarget;
+typedef struct IDCompositionTargetVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(IDCompositionTarget*, REFIID, void**);
+    ULONG   (STDMETHODCALLTYPE *AddRef)(IDCompositionTarget*);
+    ULONG   (STDMETHODCALLTYPE *Release)(IDCompositionTarget*);
+    HRESULT (STDMETHODCALLTYPE *SetRoot)(IDCompositionTarget*, IDCompositionVisual*);
+} IDCompositionTargetVtbl;
+struct IDCompositionTarget { IDCompositionTargetVtbl* lpVtbl; };
+
+// Minimal IDCompositionDevice vtable
+typedef struct IDCompositionDevice IDCompositionDevice;
+typedef struct IDCompositionDeviceVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(IDCompositionDevice*, REFIID, void**);
+    ULONG   (STDMETHODCALLTYPE *AddRef)(IDCompositionDevice*);
+    ULONG   (STDMETHODCALLTYPE *Release)(IDCompositionDevice*);
+    HRESULT (STDMETHODCALLTYPE *Commit)(IDCompositionDevice*);
+    HRESULT (STDMETHODCALLTYPE *WaitForCommitCompletion)(IDCompositionDevice*);
+    HRESULT (STDMETHODCALLTYPE *GetFrameStatistics)(IDCompositionDevice*, void*);
+    HRESULT (STDMETHODCALLTYPE *CreateTargetForHwnd)(IDCompositionDevice*, HWND, BOOL, IDCompositionTarget**);
+    HRESULT (STDMETHODCALLTYPE *CreateVisual)(IDCompositionDevice*, IDCompositionVisual**);
+} IDCompositionDeviceVtbl;
+struct IDCompositionDevice { IDCompositionDeviceVtbl* lpVtbl; };
+
+// DCompositionCreateDevice is a flat C export from dcomp.dll
+HRESULT WINAPI DCompositionCreateDevice(IDXGIDevice*, REFIID, void**);
+
+#define IDCompositionDevice_CreateTargetForHwnd(p,a,b,c) (p)->lpVtbl->CreateTargetForHwnd(p,a,b,c)
+#define IDCompositionDevice_CreateVisual(p,a)            (p)->lpVtbl->CreateVisual(p,a)
+#define IDCompositionDevice_Commit(p)                    (p)->lpVtbl->Commit(p)
+#define IDCompositionDevice_Release(p)                   (p)->lpVtbl->Release(p)
+#define IDCompositionTarget_SetRoot(p,a)                 (p)->lpVtbl->SetRoot(p,a)
+#define IDCompositionTarget_Release(p)                   (p)->lpVtbl->Release(p)
+#define IDCompositionVisual_SetContent(p,a)              (p)->lpVtbl->SetContent(p,a)
+#define IDCompositionVisual_Release(p)                   (p)->lpVtbl->Release(p)
 
 #include "d3d11_impl.h"
 
@@ -27,6 +99,9 @@ struct DxDevice {
     ID3D11BlendState* blend_off;
     ID3D11RasterizerState* rasterizer_state;
     ID3D11SamplerState* default_sampler;
+    IDCompositionDevice* dcomp_device;
+    IDCompositionTarget* dcomp_target;
+    IDCompositionVisual* dcomp_visual;
     D3D_FEATURE_LEVEL feature_level;
     HWND hwnd;
     uint32_t bb_width;
@@ -69,7 +144,9 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
         return NULL;
     }
 
-    // Create swap chain via DXGI 1.2 for DXGI_SCALING_NONE (prevents DWM stretching on resize)
+    // Create swap chain for composition (not bound to HWND directly).
+    // This allows DirectComposition to control visibility without crashing
+    // the D3D driver when a surface is hidden during tab switching.
     IDXGIDevice* dxgi_device = NULL;
     IDXGIAdapter* adapter = NULL;
     IDXGIFactory2* factory = NULL;
@@ -85,27 +162,42 @@ DxDevice* dx_create(void* hwnd, uint32_t width, uint32_t height) {
     scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     scd.BufferCount = 2;
     scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    scd.Scaling = DXGI_SCALING_NONE;
+    scd.Scaling = DXGI_SCALING_STRETCH;
+    scd.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 
     IDXGISwapChain1* swap_chain1 = NULL;
-    hr = IDXGIFactory2_CreateSwapChainForHwnd(factory, (IUnknown*)dev->device, dev->hwnd, &scd, NULL, NULL, &swap_chain1);
-
-    // Disable DXGI's automatic Alt+Enter fullscreen handling. The host app
-    // implements fullscreen by toggling Win32 window styles instead, and DXGI
-    // refuses SetFullscreenState on swap chains targeting child windows.
-    IDXGIFactory_MakeWindowAssociation((IDXGIFactory*)factory, dev->hwnd, DXGI_MWA_NO_ALT_ENTER);
+    hr = IDXGIFactory2_CreateSwapChainForComposition(factory, (IUnknown*)dev->device, &scd, NULL, &swap_chain1);
 
     IDXGIFactory2_Release(factory);
     IDXGIAdapter_Release(adapter);
-    IDXGIDevice_Release(dxgi_device);
 
     if (FAILED(hr) || !swap_chain1) {
-        OutputDebugStringA("D3D11: CreateSwapChainForHwnd FAILED\n");
+        OutputDebugStringA("D3D11: CreateSwapChainForComposition FAILED\n");
+        IDXGIDevice_Release(dxgi_device);
         ID3D11DeviceContext_Release(dev->context);
         ID3D11Device_Release(dev->device);
         free(dev);
         return NULL;
     }
+
+    // Set up DirectComposition: visual tree routes the swap chain to the HWND.
+    // Visibility is controlled by attaching/detaching the visual root.
+    hr = DCompositionCreateDevice((IDXGIDevice*)dxgi_device, &IID_IDCompositionDevice, (void**)&dev->dcomp_device);
+    IDXGIDevice_Release(dxgi_device);
+    if (FAILED(hr)) {
+        OutputDebugStringA("D3D11: DCompositionCreateDevice FAILED\n");
+        IDXGISwapChain1_Release(swap_chain1);
+        ID3D11DeviceContext_Release(dev->context);
+        ID3D11Device_Release(dev->device);
+        free(dev);
+        return NULL;
+    }
+
+    IDCompositionDevice_CreateTargetForHwnd(dev->dcomp_device, dev->hwnd, TRUE, &dev->dcomp_target);
+    IDCompositionDevice_CreateVisual(dev->dcomp_device, &dev->dcomp_visual);
+    IDCompositionVisual_SetContent(dev->dcomp_visual, (IUnknown*)swap_chain1);
+    IDCompositionTarget_SetRoot(dev->dcomp_target, dev->dcomp_visual);
+    IDCompositionDevice_Commit(dev->dcomp_device);
 
     // Get IDXGISwapChain from IDXGISwapChain1
     IDXGISwapChain1_QueryInterface(swap_chain1, &IID_IDXGISwapChain, (void**)&dev->swap_chain);
@@ -173,6 +265,9 @@ void dx_destroy(DxDevice* dev) {
         ID3D11DeviceContext_ClearState(dev->context);
         ID3D11DeviceContext_Flush(dev->context);
     }
+    if (dev->dcomp_visual) IDCompositionVisual_Release(dev->dcomp_visual);
+    if (dev->dcomp_target) IDCompositionTarget_Release(dev->dcomp_target);
+    if (dev->dcomp_device) IDCompositionDevice_Release(dev->dcomp_device);
     if (dev->default_sampler) ID3D11SamplerState_Release(dev->default_sampler);
     if (dev->rasterizer_state) ID3D11RasterizerState_Release(dev->rasterizer_state);
     if (dev->blend_off) ID3D11BlendState_Release(dev->blend_off);
@@ -656,5 +751,13 @@ void dx_get_window_size(DxDevice* dev, uint32_t* width, uint32_t* height) {
         *width = 0;
         *height = 0;
     }
+}
+
+// --- DirectComposition visibility ---
+
+void dx_set_visible(DxDevice* dev, bool visible) {
+    if (!dev || !dev->dcomp_target) return;
+    IDCompositionTarget_SetRoot(dev->dcomp_target, visible ? dev->dcomp_visual : NULL);
+    IDCompositionDevice_Commit(dev->dcomp_device);
 }
 

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -90,9 +90,9 @@ DxPipeline* dx_create_image_pipeline(DxDevice* dev, const void* vs_bytecode, uin
 DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode, uint32_t vs_size,
                                           const void* ps_bytecode, uint32_t ps_size);
 
-// Window resize notification (thread-safe, called from main thread)
-void dx_set_window_size(uint32_t width, uint32_t height);
-void dx_get_window_size(uint32_t* width, uint32_t* height);
+// Per-device window resize notification (thread-safe, called from main thread)
+void dx_set_window_size(DxDevice* dev, uint32_t width, uint32_t height);
+void dx_get_window_size(DxDevice* dev, uint32_t* width, uint32_t* height);
 
 #ifdef __cplusplus
 }

--- a/src/renderer/directx/d3d11_impl.h
+++ b/src/renderer/directx/d3d11_impl.h
@@ -94,6 +94,9 @@ DxPipeline* dx_create_cell_text_pipeline(DxDevice* dev, const void* vs_bytecode,
 void dx_set_window_size(DxDevice* dev, uint32_t width, uint32_t height);
 void dx_get_window_size(DxDevice* dev, uint32_t* width, uint32_t* height);
 
+// DirectComposition visibility control (safe to call while renderer is active)
+void dx_set_visible(DxDevice* dev, bool visible);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary / 概要

Switch the DirectX 11 renderer from HWND-bound swap chains to DirectComposition-based swap chains, enabling safe multi-tab support.

<details><summary>日本語</summary>

DirectX 11 レンダラーの HWND バインドスワップチェーンを DirectComposition ベースに変更し、安全なマルチタブ対応を実現。

</details>

## Changes / 変更

### Modified Files / 変更ファイル

| File | Change |
|------|--------|
| `src/renderer/directx/d3d11_impl.c` | DirectComposition visual tree setup, `CreateSwapChainForComposition`, per-device sampler/state, `dx_set_visible`, `ClearState+Flush` on destroy |
| `src/renderer/directx/d3d11_impl.h` | Add `dx_set_visible` declaration |
| `src/renderer/directx/Pipeline.zig` | Deduplicate shader source by pointer identity, per-device pipeline handle cache |
| `src/renderer/DirectX.zig` | Threadlocal `current_device`, `dx_set_surface_visible` export, device teardown in `threadEnter` |
| `src/apprt/embedded.zig` | Export `ghostty_surface_dx_device` for per-surface device access |

## Technical Decisions / 技術的決定

**DirectComposition over HWND swap chains**: `ShowWindow(SW_HIDE)` on a window with an active D3D11 swap chain crashes NVIDIA drivers. DirectComposition decouples the swap chain from the HWND — `SetRoot(NULL)` hides the visual while `Present()` continues safely. This matches Windows Terminal's architecture.

<details><summary>日本語</summary>

アクティブな D3D11 スワップチェーンを持つウィンドウに `ShowWindow(SW_HIDE)` すると NVIDIA ドライバーがクラッシュする。DirectComposition はスワップチェーンを HWND から分離し、`SetRoot(NULL)` で `Present()` を安全に継続したままビジュアルを非表示にできる。Windows Terminal と同じアーキテクチャ。

</details>

**Manual COM vtable declarations**: `dcomp.h` is C++-only and incompatible with Zig's C compiler. Minimal vtable structs for `IDCompositionDevice/Target/Visual` are declared manually with correct slot offsets for overloaded methods.

<details><summary>日本語</summary>

`dcomp.h` は C++ 専用で Zig の C コンパイラと非互換。`IDCompositionDevice/Target/Visual` の最小 vtable 構造体をオーバーロードメソッドの正しいスロットオフセットで手動宣言。

</details>

**Pipeline source deduplication**: Each surface called `storeSource` allocating a new global ID. With 5 shaders × N surfaces, the fixed-size array overflowed at 4 surfaces. Now deduplicates by pointer identity — comptime-embedded HLSL has stable addresses.

<details><summary>日本語</summary>

各サーフェスが `storeSource` で新しいグローバル ID を割り当てていた。5 シェーダー × N サーフェスで固定サイズ配列が 4 サーフェスでオーバーフロー。ポインタ同一性で重複排除 — コンパイル時埋め込み HLSL はアドレスが安定。

</details>

## Build / ビルド

```
zig build -Doptimize=ReleaseSafe -Drenderer=directx
```

## Known Issues / 既知の問題

- #22 — Tab creation flicker (new surface visible before first render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)