### PR TITLE
DirectX 11: route resize and visibility through generic renderer hooks

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -831,6 +831,15 @@ pub const Surface = struct {
             .height = height,
         };
 
+        // Notify the graphics API synchronously from this (main) thread.
+        // DirectX uses this so the renderer thread picks up the new
+        // window size on the very next frame, without the asynchronous
+        // round trip through the renderer thread mailbox.
+        const Api = @TypeOf(self.core_surface.renderer.api);
+        if (comptime @hasDecl(Api, "notifyResize")) {
+            self.core_surface.renderer.api.notifyResize(width, height);
+        }
+
         // Call the primary callback.
         self.core_surface.sizeCallback(self.size) catch |err| {
             log.err("error in size callback err={}", .{err});

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1592,17 +1592,6 @@ pub const CAPI = struct {
         return surface.userdata;
     }
 
-    /// Returns the DirectX device pointer for per-surface resize notification.
-    /// Returns null on non-DirectX backends.
-    export fn ghostty_surface_dx_device(surface: *Surface) ?*anyopaque {
-        if (comptime @hasField(@TypeOf(surface.core_surface.renderer.api), "device")) {
-            if (surface.core_surface.renderer.api.device) |dev| {
-                return @ptrCast(dev);
-            }
-        }
-        return null;
-    }
-
     /// Returns the app associated with a surface.
     export fn ghostty_surface_app(surface: *Surface) *App {
         return surface.app;

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -37,12 +37,12 @@ pub fn setVisible(self: *DirectX, visible: bool) void {
     dx.dx_set_visible(dev, visible);
 }
 
-/// Called by the renderer when the screen size changes. Stores the new
-/// window size on the device so surfaceSize() picks it up next frame.
-/// Safe to call from the renderer thread.
+/// Called from the apprt updateSize path (main thread) to update the
+/// device's window size synchronously. This avoids the renderer thread
+/// needing to do a cross-thread GetClientRect on the HWND.
+/// Writes an atomic field; safe from any thread.
 pub fn notifyResize(self: *DirectX, w: u32, h: u32) void {
-    _ = self;
-    const dev = current_device orelse return;
+    const dev = self.device orelse return;
     dx.dx_set_window_size(dev, w, h);
 }
 

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -28,16 +28,22 @@ pub const custom_shader_target: shadertoy.Target = .glsl;
 pub const custom_shader_y_is_down = true;
 pub const swap_chain_count = 2;
 
-/// Called from C++ WM_SIZE to update window size without cross-thread deadlock.
-/// Takes the device pointer so each surface's size is tracked independently.
-export fn dx_notify_resize(dev: ?*dx.DxDevice, w: u32, h: u32) void {
-    dx.dx_set_window_size(dev, w, h);
+/// Called by the renderer when occlusion changes. Toggles the
+/// DirectComposition visual so the GPU can stop compositing hidden surfaces.
+/// Safe to call from the renderer thread.
+pub fn setVisible(self: *DirectX, visible: bool) void {
+    _ = self;
+    const dev = current_device orelse return;
+    dx.dx_set_visible(dev, visible);
 }
 
-/// Called from C++ to show/hide a surface's DirectComposition visual (tab switching).
-/// Safe to call from main thread while the renderer is active on another thread.
-export fn dx_set_surface_visible(dev: ?*dx.DxDevice, visible: bool) void {
-    dx.dx_set_visible(dev, visible);
+/// Called by the renderer when the screen size changes. Stores the new
+/// window size on the device so surfaceSize() picks it up next frame.
+/// Safe to call from the renderer thread.
+pub fn notifyResize(self: *DirectX, w: u32, h: u32) void {
+    _ = self;
+    const dev = current_device orelse return;
+    dx.dx_set_window_size(dev, w, h);
 }
 
 /// Use a native Windows render loop instead of xev.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1934,13 +1934,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             self.updateScreenSizeUniforms();
 
-            // Forward raw pixel size to the graphics API if it has a hook.
-            // (DirectX uses this so the renderer thread can pick up the new
-            // window size without calling GetClientRect cross-thread.)
-            if (comptime @hasDecl(GraphicsAPI, "notifyResize")) {
-                self.api.notifyResize(size.screen.width, size.screen.height);
-            }
-
             log.debug("screen size size={}", .{size});
         }
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1062,6 +1062,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     display_link.stop() catch {};
                 }
             }
+
+            // Forward to the graphics API if it has a setVisible hook.
+            // (Used by DirectX to toggle DirectComposition visual visibility.)
+            if (comptime @hasDecl(GraphicsAPI, "setVisible")) {
+                self.api.setVisible(visible);
+            }
         }
 
         /// Set the new font grid.
@@ -1927,6 +1933,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.size.padding = size.padding;
 
             self.updateScreenSizeUniforms();
+
+            // Forward raw pixel size to the graphics API if it has a hook.
+            // (DirectX uses this so the renderer thread can pick up the new
+            // window size without calling GetClientRect cross-thread.)
+            if (comptime @hasDecl(GraphicsAPI, "notifyResize")) {
+                self.api.notifyResize(size.screen.width, size.screen.height);
+            }
 
             log.debug("screen size size={}", .{size});
         }


### PR DESCRIPTION
## Summary / 概要

Move DirectX-specific resize and visibility side-effects out of the embedded C API and into generic renderer / apprt hooks. The host (GhosttyWin32) can now use the renderer-agnostic `ghostty_surface_set_size` / `ghostty_surface_set_occlusion` APIs and link against either DirectX or OpenGL builds of `ghostty.dll` with the same binary.

<details><summary>日本語</summary>

DirectX 固有のリサイズ・可視性の副作用を embedded C API から取り除き、generic renderer / apprt の既存フックに移動。ホスト (GhosttyWin32) は renderer 非依存の `ghostty_surface_set_size` / `ghostty_surface_set_occlusion` を呼ぶだけで済み、同じバイナリで DirectX / OpenGL どちらの `ghostty.dll` ビルドにもリンクできる。

</details>

## Changes / 変更

### Modified Files / 変更ファイル

| File | Change |
|------|--------|
| `src/renderer/DirectX.zig` | Replace the `dx_notify_resize` / `dx_set_surface_visible` exports with `setVisible` and `notifyResize` methods on the `DirectX` graphics API. `notifyResize` reads `self.device` so it is safe to call from the main thread. |
| `src/renderer/generic.zig` | In the cell renderer's `setVisible`, forward to `api.setVisible` when the graphics API declares it (compile-time `@hasDecl` check, no runtime cost on other backends). |
| `src/apprt/embedded.zig` | In `updateSize`, forward to `api.notifyResize` synchronously from the main thread when the graphics API declares it. Remove `ghostty_surface_dx_device` — no longer needed. |

## Technical Decisions / 技術的決定

### Renderer-agnostic public API

The previous design exposed three DirectX-internal symbols (`dx_notify_resize`, `dx_set_surface_visible`, `ghostty_surface_dx_device`) so the host could:

1. Pull a renderer-internal `DxDevice*` out of a `Surface`.
2. Call DirectX size/visibility functions directly on the main thread.

This required the host to know it was talking to a DirectX renderer, made the C API renderer-dependent, and broke linkage when `ghostty.dll` was built with `-Drenderer=opengl` (the symbols simply did not exist).

The macOS apprt already uses the renderer-agnostic `ghostty_surface_set_size` and `ghostty_surface_set_occlusion`. Visibility already routes through the renderer thread mailbox (`.visible` → `setVisible`), so adding a small `@hasDecl`-gated forward in the generic `setVisible` is enough to give DirectX the same hook without polluting other backends. `ghostty_surface_set_occlusion` goes straight into that flow unchanged.

### Resize must be synchronous from the main thread

Resize could not use the same mailbox path. `sizeCallback` posts `.resize`, which is handled on the renderer thread via `setScreenSize` — one frame later, at the earliest. In practice, the renderer thread's next `surfaceSize()` query then fell back to the device's stale window size, producing a wrong-width first frame after surface creation.

The host's original `dx_notify_resize` worked because it ran synchronously on the main thread, before the renderer thread got a chance to query. To preserve that timing the `notifyResize` hook is wired into apprt's `updateSize` (which also runs on the caller's thread) and reads `self.device` directly instead of the threadlocal `current_device`. The underlying `dx_set_window_size` only writes an atomic field, so calling it from the main thread is safe.

<details><summary>日本語</summary>

### Renderer 非依存な公開 API

従来は DirectX 内部シンボル 3 つ (`dx_notify_resize` / `dx_set_surface_visible` / `ghostty_surface_dx_device`) を export することで、ホストが:

1. `Surface` から renderer 内部の `DxDevice*` を取り出す
2. メインスレッドから直接 DirectX のサイズ・可視性関数を呼ぶ

という流れだった。これによりホストは「DirectX renderer と話している」ことを意識する必要があり、C API が renderer 依存になり、`-Drenderer=opengl` ビルドの `ghostty.dll` とはリンクできなかった。

macOS apprt は既に renderer 非依存の `ghostty_surface_set_size` / `ghostty_surface_set_occlusion` を使用。可視性は renderer thread mailbox (`.visible` → `setVisible`) で処理されるため、generic 側の `setVisible` に `@hasDecl` ガードでフォワードを足せば、他のバックエンドに影響せず DirectX 用フックを追加できる。`ghostty_surface_set_occlusion` はそのまま使える。

### リサイズはメインスレッドから同期呼び出し

リサイズだけは同じ mailbox 経路に乗せられなかった。`sizeCallback` が `.resize` を post し、renderer thread 側で `setScreenSize` として処理されるが、これは最短でも 1 フレーム後。実際に試したところ renderer thread の次の `surfaceSize()` 問い合わせで古いウィンドウサイズにフォールバックしてしまい、サーフェイス作成直後の初回フレームで幅が誤った状態でレンダリングされた。

ホスト側の元の `dx_notify_resize` が動いていたのは、メインスレッドから同期的に実行されていたから。このタイミングを維持するため `notifyResize` フックを apprt の `updateSize`（呼び出し元スレッドで動く）に接続し、threadlocal の `current_device` ではなく `self.device` を参照する実装に変更。下位の `dx_set_window_size` はアトミック変数への書き込みのみなので、メインスレッドから呼んでも安全。

</details>

## Build / ビルド

```bash
zig build -Doptimize=ReleaseSafe -Drenderer=directx -Dapp-runtime=none
zig build -Doptimize=ReleaseSafe -Drenderer=opengl  -Dapp-runtime=none
```

Both renderer builds compile cleanly. The host-side changes consuming the new API are in i999rri/GhosttyWin32#23.

<details><summary>日本語</summary>

両 renderer のビルドが通る。新 API を利用するホスト側変更は i999rri/GhosttyWin32#23。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)