### PR TITLE
windows: skip path resolution for ':' inputs in resolvePathForOpening

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2067,6 +2067,19 @@ fn resolvePathForOpening(
     path: []const u8,
 ) Allocator.Error!?[]const u8 {
     if (!std.fs.path.isAbsolute(path)) {
+        // On Windows, ':' is only valid in a file path at offset 1 (the
+        // drive-letter separator). Anywhere else it indicates either a
+        // URL scheme separator (e.g. "https://..."), an NTFS alternate
+        // data stream, or a line/column suffix tacked on by the URL
+        // regex (e.g. "src/foo.zig:42:10"). Resolving any of those against
+        // pwd produces a path the NT layer rejects with
+        // STATUS_OBJECT_NAME_INVALID, which Zig's std.fs.accessAbsolute
+        // treats as `unreachable` and panics (issue
+        // i999rri/GhosttyWin32#12). Skip resolution in that case — the
+        // caller falls back to opening `path` as-is.
+        if (builtin.os.tag == .windows and
+            std.mem.indexOfScalar(u8, path, ':') != null) return null;
+
         const terminal_pwd = self.io.terminal.getPwd() orelse {
             return null;
         };


### PR DESCRIPTION
## Summary

Fix Ctrl+click crash on Windows: `resolvePathForOpening` panics inside `std.fs.accessAbsolute` when the URL regex matches a string containing a `:` (URL schemes, line/col suffixes). Skip resolution for such inputs and let the caller fall back to opening the raw `path`.

Repro / write-up: i999rri/GhosttyWin32#12.

## Root cause

```
processLinks
  -> resolvePathForOpening("https://example.com")
     -> std.fs.path.resolve(pwd, "https://example.com")
        = "C:\Users\x\https:\example.com"
     -> std.fs.accessAbsolute(...)
        -> NtQueryAttributesFile -> STATUS_OBJECT_NAME_INVALID
        -> `OBJECT_NAME_INVALID => unreachable` (panic -> ExitProcess(3))
```

NT rejects the resolved path because the embedded `:` from the URL scheme isn't valid mid-path on Windows. Zig's stdlib classifies that NT status as unreachable, so the catch on `accessAbsolute` never runs.

## Test plan

- [x] Manual: Ctrl+click `https://example.com` in GhosttyWin32 → opens browser instead of exit(3).
- [x] Manual: Ctrl+click `src/Surface.zig:42:10` → does not panic, falls through to caller.
- [x] `zig build -Doptimize=ReleaseSafe -Drenderer=directx` succeeds.
