### PR TITLE
apprt/embedded: expose swap_chain_changed_cb for host-side composition transforms

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -481,6 +481,22 @@ typedef struct {
   // swap chain exists.
   void (*swap_chain_ready_cb)(void* userdata);
   void* swap_chain_ready_userdata;
+  // Optional callback fired on ghostty's renderer thread after the swap
+  // chain has been resized (i.e. ResizeBuffers completed) or after a
+  // DPI / content scale change has been applied to the renderer. The
+  // first argument is the IDXGISwapChain1* the renderer is using; the
+  // host MUST NOT release this reference (ghostty retains ownership).
+  // The host can `QueryInterface` it to IDXGISwapChain2 and install
+  // platform-specific transforms (for example, a 1/CompositionScale
+  // matrix to cancel XAML SwapChainPanel's automatic upscale of
+  // attached content). The callback fires once after the swap chain is
+  // first bound (so the host can install initial state), and again on
+  // every subsequent resize / DPI change so transforms that some
+  // drivers reset on ResizeBuffers can be re-installed. ghostty has no
+  // knowledge of what the host installs; the policy lives entirely in
+  // the callback. Set to null to opt out.
+  void (*swap_chain_changed_cb)(void* swap_chain, void* userdata);
+  void* swap_chain_changed_userdata;
   // Initial swap chain dimensions in pixels. Used when set (non-zero) so the
   // swap chain is created at the correct size from the start, avoiding an
   // immediate ResizeBuffers on the first frame. When zero, ghostty falls back

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -395,6 +395,18 @@ pub const Platform = union(PlatformTag) {
         /// premature — the back buffer is undefined until first present.)
         swap_chain_ready_cb: ?*const fn (?*anyopaque) callconv(.c) void = null,
         swap_chain_ready_userdata: ?*anyopaque = null,
+        /// Optional callback fired on ghostty's renderer thread after the
+        /// swap chain has been (re)bound or its effective DPI has
+        /// changed. The first argument is the IDXGISwapChain1* the
+        /// renderer is currently using; the host must NOT release it.
+        /// Use this to install platform-specific transforms — e.g. a
+        /// 1/CompositionScale matrix that cancels XAML SwapChainPanel's
+        /// implicit upscale on attached content. ghostty is intentionally
+        /// unaware of the host's policy; it just notifies. Fires once
+        /// at initial bind, then on every resize / DPI change so
+        /// transforms reset by ResizeBuffers can be re-installed.
+        swap_chain_changed_cb: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.c) void = null,
+        swap_chain_changed_userdata: ?*anyopaque = null,
         /// Initial swap chain dimensions. When non-zero, used instead of
         /// querying the HWND's client rect — saves an immediate ResizeBuffers
         /// on the first frame when the host knows the actual panel size.
@@ -422,6 +434,8 @@ pub const Platform = union(PlatformTag) {
             composition_surface_handle: ?*anyopaque,
             swap_chain_ready_cb: ?*const fn (?*anyopaque) callconv(.c) void,
             swap_chain_ready_userdata: ?*anyopaque,
+            swap_chain_changed_cb: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.c) void,
+            swap_chain_changed_userdata: ?*anyopaque,
             initial_width: u32,
             initial_height: u32,
         },
@@ -458,6 +472,8 @@ pub const Platform = union(PlatformTag) {
                     .composition_surface_handle = config.composition_surface_handle,
                     .swap_chain_ready_cb = config.swap_chain_ready_cb,
                     .swap_chain_ready_userdata = config.swap_chain_ready_userdata,
+                    .swap_chain_changed_cb = config.swap_chain_changed_cb,
+                    .swap_chain_changed_userdata = config.swap_chain_changed_userdata,
                     .initial_width = config.initial_width,
                     .initial_height = config.initial_height,
                 } };

--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -116,6 +116,20 @@ const Presentation = struct {
     ready_cb: ?*const fn (?*anyopaque) callconv(.c) void = null,
     ready_userdata: ?*anyopaque = null,
     ready_fired: bool = false,
+
+    /// "Swap chain state changed" callback. Fires on the renderer thread
+    /// after the initial bind, after `dx_resize` (i.e. ResizeBuffers),
+    /// and after a DPI change has flowed through the renderer. The host
+    /// receives the IDXGISwapChain1* and can install / re-install
+    /// platform-specific transforms in its own code path; ghostty does
+    /// not interpret what the host does with the swap chain. This split
+    /// keeps the WinUI 3 / SwapChainPanel inverse-scale workaround on
+    /// the host side, leaving the renderer responsible only for "when".
+    /// Only populated on the composition-surface path; the HWND path
+    /// owns its DComp visual directly and has no implicit upscale to
+    /// undo.
+    swap_chain_changed_cb: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.c) void = null,
+    swap_chain_changed_userdata: ?*anyopaque = null,
 };
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX {
@@ -238,11 +252,46 @@ pub fn threadEnter(self: *const DirectX, surface: *apprt.Surface) !void {
     if (used_composition_surface) {
         self.presentation.ready_cb = platform.swap_chain_ready_cb;
         self.presentation.ready_userdata = platform.swap_chain_ready_userdata;
+
+        // Stash the swap-chain-changed callback only on the composition-
+        // surface path — the HWND path uses our own DComp visual and
+        // doesn't get the implicit XAML upscale that motivates this
+        // callback. Fire it once now so the host can install any
+        // initial transforms (e.g. an inverse-scale matrix) on the
+        // freshly bound swap chain before the first present.
+        self.presentation.swap_chain_changed_cb = platform.swap_chain_changed_cb;
+        self.presentation.swap_chain_changed_userdata = platform.swap_chain_changed_userdata;
+        self.fireSwapChainChanged();
     }
+}
+
+/// Fire the host's "swap chain state changed" callback (initial bind,
+/// post-resize, post-DPI-change). No-op when the callback isn't
+/// registered (HWND path, or host doesn't need the hook). Renderer
+/// thread.
+fn fireSwapChainChanged(self: *const DirectX) void {
+    const cb = self.presentation.swap_chain_changed_cb orelse return;
+    const dev = self.presentation.device orelse return;
+    const sc = dx.dx_get_swap_chain(dev) orelse return;
+    cb(sc, self.presentation.swap_chain_changed_userdata);
 }
 
 pub fn threadExit(self: *const DirectX) void {
     _ = self;
+}
+
+/// Called by `generic.Renderer.setFontGrid` whenever the font / DPI
+/// changes. The renderer itself doesn't care about the new DPI on the
+/// DirectX path — the only consumer is the host, which may want to
+/// re-install platform-specific transforms (e.g. a 1/CompositionScale
+/// matrix) on the swap chain. We forward to `fireSwapChainChanged` so
+/// the host runs the same code path used at initial bind and after
+/// `dx_resize`. The `xdpi` argument is unused at this level but kept
+/// for symmetry with the generic hook.
+pub fn applyFontDpiToTransforms(self: *DirectX, xdpi: u16) void {
+    _ = xdpi;
+    if (comptime builtin.os.tag != .windows) return;
+    self.fireSwapChainChanged();
 }
 
 pub fn displayRealized(self: *const DirectX) void {
@@ -296,6 +345,10 @@ pub fn surfaceSize(self: *const DirectX) !struct { width: u32, height: u32 } {
         dx.dx_get_backbuffer_size(dev, &bbw, &bbh);
         if (bbw != ww or bbh != wh) {
             dx.dx_resize(dev, ww, wh);
+            // ResizeBuffers can drop driver-level swap-chain state (some
+            // drivers reset transforms set via SetMatrixTransform), so
+            // give the host a chance to re-install whatever it owns.
+            self.fireSwapChainChanged();
         }
         return .{ .width = ww, .height = wh };
     }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1110,6 +1110,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Update relevant uniforms
             self.updateFontGridUniforms();
 
+            // Backends that need DPI-dependent notifications (currently
+            // just DirectX, which forwards to a host callback so the
+            // host can re-install platform-specific transforms on its
+            // swap chain) get notified here. Backends without a
+            // matching method simply don't declare it and the branch
+            // compiles away.
+            if (comptime @hasDecl(API, "applyFontDpiToTransforms")) {
+                if (grid.resolver.collection.load_options) |opts| {
+                    self.api.applyFontDpiToTransforms(opts.size.xdpi);
+                }
+            }
+
             // Force a full rebuild, because cached rows may still reference
             // an outdated atlas from the old grid and this can cause garbage
             // to be rendered.


### PR DESCRIPTION
## Summary
Some XAML-like composition hosts (Microsoft.UI.Xaml.SwapChainPanel through `ISwapChainPanelNative2::SetSwapChainHandle` is the motivating case) implicitly upscale attached swap-chain content by their own CompositionScale. Cancelling that upscale needs `IDXGISwapChain2::SetMatrixTransform({ 96/dpi, 96/dpi })` — and that matrix is reset on ResizeBuffers on some drivers, so it has to be re-installed at every resize / DPI change / initial bind.

Putting this workaround inside libghostty's DirectX renderer would mix XAML-specific policy into a cross-platform, host-agnostic library. Instead this PR exposes a renderer-thread callback that the host can register:

```c
void (*swap_chain_changed_cb)(void* swap_chain, void* userdata);
```

The callback receives the `IDXGISwapChain1*` libghostty is using; the host owns the policy of what (if anything) to install on it (`QueryInterface IDXGISwapChain2`, `SetMatrixTransform`, etc.). libghostty has no opinion about the host's transforms.

## Why
Without this hook, a host can't install a workaround for the SwapChainPanel auto-stretch in a robust way:

- The transform must be re-applied after `ResizeBuffers`, but `ghostty_surface_set_size` is async (queues a resize to the renderer thread). A host listening only to XAML `SizeChanged` would race the renderer thread and the transform could be lost for 1+ frames.
- A pull-only solution (`dx_get_swap_chain` from the host) doesn't know when `ResizeBuffers` actually completed.

## Where the callback fires (renderer thread)
1. **Initial bind** — once at `threadEnter`, immediately after the swap chain is created and device set up. Lets the host install initial state before the first present.
2. **After `dx_resize`** — after `ResizeBuffers`, so drivers that reset swap-chain transforms get a fresh re-install opportunity.
3. **After font / DPI change** — flowed through `generic.Renderer.setFontGrid` via a new `applyFontDpiToTransforms` hook on the backend. Guarded with `comptime @hasDecl(API, ...)` so OpenGL / Metal backends compile away.

## What this PR does NOT do
- libghostty does not call `SetMatrixTransform` or know about WinUI 3. The actual matrix install lives on the host side.
- HWND callers are unaffected — they don't register the callback and never see it fire (the registration check is gated on the composition-surface path inside `threadEnter`).

## Test plan
- [x] macOS Retina → RDP → Windows server: host (GhosttyWin32) registers the callback and installs `SetMatrixTransform({ 96/dpi, 96/dpi })`. Text and background image match Windows Terminal at the same `font-size` setting.
- [x] Local non-HiDPI Windows: callback fires but matrix is identity at scale 1.0 (no visible change).
- [x] Host-side DPI change (drag between monitors): `setFontGrid` hook fires the callback, host re-applies the matrix.
- [x] Resize: `dx_resize` fires the callback, host re-installs after ResizeBuffers.
- [x] OpenGL / Metal: `@hasDecl` branch compiles away (verified by inspection — only DirectX backend declares `applyFontDpiToTransforms`).

## Files
- `include/ghostty.h` — new `swap_chain_changed_cb` / `swap_chain_changed_userdata` in `ghostty_platform_windows_s`
- `src/apprt/embedded.zig` — Platform.windows + C ABI struct + init wiring
- `src/renderer/DirectX.zig` — Presentation storage, threadEnter stash + initial fire, post-`dx_resize` fire, `applyFontDpiToTransforms` hook, `fireSwapChainChanged` helper
- `src/renderer/generic.zig` — `setFontGrid` invokes `applyFontDpiToTransforms` via `comptime @hasDecl`