### PR TITLE
Hybrid cadence for the native Windows render loop

### DIFF
--- a/src/renderer/DirectX.zig
+++ b/src/renderer/DirectX.zig
@@ -130,6 +130,15 @@ const Presentation = struct {
     /// undo.
     swap_chain_changed_cb: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.c) void = null,
     swap_chain_changed_userdata: ?*anyopaque = null,
+
+    /// Set by `present` (via Frame.complete) when a full frame was
+    /// drawn this drawFrame cycle; consumed by `drawFrameEnd` to decide
+    /// whether to actually Present. drawFrameStart clears the backbuffer
+    /// to opaque black before we know if there's anything to draw, so
+    /// presenting unconditionally flashes black on every path that
+    /// skips drawing (no-redraw, zero surface size, synchronized
+    /// output). Renderer-thread only.
+    frame_drawn: bool = false,
 };
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX {
@@ -315,6 +324,16 @@ pub fn drawFrameStart(self: *DirectX) void {
 
 pub fn drawFrameEnd(self: *DirectX) void {
     const dev = self.presentation.device orelse return;
+
+    // Only present when a frame was actually completed this cycle
+    // (Frame.complete -> present sets the flag). On the skip paths the
+    // backbuffer holds only drawFrameStart's opaque-black clear;
+    // presenting it would flash. Flip-model DWM keeps showing the last
+    // presented frame, so skipping is correct (presentLastTarget is a
+    // no-op by design).
+    if (!self.presentation.frame_drawn) return;
+    self.presentation.frame_drawn = false;
+
     // VSync to match SwapChainPanel/DComp composition cadence.
     // With FRAME_LATENCY_WAITABLE_OBJECT, vsync prevents tearing/flicker.
     dx.dx_present(dev, true);
@@ -387,6 +406,7 @@ pub fn beginFrame(self: *DirectX, renderer: *Renderer, target: *Target) !Frame {
 
 pub fn present(self: *DirectX, target: Target) !void {
     self.last_target = target;
+    self.presentation.frame_drawn = true;
 }
 
 pub fn presentLastTarget(self: *DirectX) !void {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -19,6 +19,11 @@ const log = std.log.scoped(.renderer_thread);
 const DRAW_INTERVAL = 8; // 120 FPS
 const CURSOR_BLINK_INTERVAL = 600;
 
+/// Native render loop safety net (ms): force a full update+draw this
+/// often even with no wakeup/mailbox activity, so a dropped notify
+/// degrades to a briefly-stale frame instead of a permanently-stale one.
+const NATIVE_FORCED_REDRAW_INTERVAL = 1000;
+
 /// Whether to use a native render loop instead of xev's event loop.
 /// DirectX on Windows requires this because xev's IOCP is incompatible with D3D11.
 const use_native_loop = blk: {
@@ -119,6 +124,14 @@ flags: packed struct {
 
     /// Set by drainMailbox on reset_cursor_blink; consumed by native render loop
     cursor_blink_reset: bool = false,
+
+    /// Native render loop only. Set by wakeupCallback / drawNowCallback
+    /// when their asyncs fire through the loop.run(.no_wait) poll;
+    /// consumed by nativeRenderCycle. Both are written and read on the
+    /// renderer thread only (xev dispatch happens inside the poll), so
+    /// no atomics are needed.
+    render_requested: bool = false,
+    draw_now_requested: bool = false,
 } = .{},
 
 /// Stop flag for native render loop. Only exists when use_native_loop is true.
@@ -286,6 +299,20 @@ fn threadMain_(self: *Thread) !void {
         self.stop_requested.store(false, .monotonic);
         self.stop.wait(&self.loop, &self.stop_c, Thread, self, nativeStopCallback);
 
+        // Register the wakeup / draw-now asyncs on the same polled loop.
+        // Without these, every renderer_wakeup.notify() from termio /
+        // Surface (PTY output, resize, IME preedit, refresh) is silently
+        // dropped and the only thing that ever produces frames is the
+        // unconditional poll below — which forces redrawing every cycle
+        // "just in case". Delivery uses the identical mechanism as the
+        // stop async above, which is proven to fire through
+        // loop.run(.no_wait).
+        self.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
+        self.draw_now.wait(&self.loop, &self.draw_now_c, Thread, self, drawNowCallback);
+
+        // Prime the first frame (mirrors the xev branch).
+        self.flags.render_requested = true;
+
         const win = @import("../os/windows.zig");
         const k32 = win.exp.kernel32;
         const GetTickCount64 = k32.GetTickCount64;
@@ -315,14 +342,16 @@ fn threadMain_(self: *Thread) !void {
         };
 
         var last_blink: u64 = GetTickCount64();
+        var last_forced: u64 = GetTickCount64();
 
         while (!self.stop_requested.load(.monotonic)) {
-            // Poll xev for stop signal (non-blocking)
+            // Poll xev (non-blocking): stop / wakeup / draw-now asyncs
+            // are all delivered here.
             _ = self.loop.run(.no_wait) catch |err|
                 log.err("error in xev poll err={}", .{err});
 
             const now = GetTickCount64();
-            self.nativeRenderCycle(&last_blink, now);
+            self.nativeRenderCycle(&last_blink, &last_forced, now);
 
             // Adaptive sleep: 4ms (~240fps) when focused, 16ms (~60fps) when not
             const sleep_ms: u32 = if (self.flags.focused) 4 else 16;
@@ -414,8 +443,11 @@ fn syncDrawTimer(self: *Thread) void {
     );
 }
 
-/// Drain the mailbox.
-fn drainMailbox(self: *Thread) !void {
+/// Drain the mailbox. Returns true when at least one message was
+/// processed — the native render loop uses this as a "state may have
+/// changed, redraw" signal, which also covers producers whose wakeup
+/// notify was dropped but whose mailbox push succeeded.
+fn drainMailbox(self: *Thread) !bool {
     // There's probably a more elegant way to do this...
     //
     // This is effectively an @autoreleasepool{} block, which we need in
@@ -426,7 +458,9 @@ fn drainMailbox(self: *Thread) !void {
         void;
     defer if (builtin.os.tag.isDarwin()) pool.deinit();
 
+    var drained = false;
     while (self.mailbox.pop()) |message| {
+        drained = true;
         log.debug("mailbox message={}", .{message});
         switch (message) {
             .crash => @panic("crash request, crashing intentionally"),
@@ -575,6 +609,8 @@ fn drainMailbox(self: *Thread) !void {
             },
         }
     }
+
+    return drained;
 }
 
 fn changeConfig(self: *Thread, config: *const DerivedConfig) !void {
@@ -603,28 +639,90 @@ fn drawFrame(self: *Thread, now: bool) void {
 }
 
 /// Perform one render cycle for the native render loop.
-/// Drains mailbox, updates frame, toggles cursor blink, and draws.
-fn nativeRenderCycle(self: *Thread, last_blink: *u64, now: u64) void {
-    self.drainMailbox() catch |err|
+///
+/// Hybrid cadence:
+///
+///   * Focused surface: render every cycle, exactly like the loop
+///     always did. On a high-refresh monitor (240 Hz = 4.2 ms/frame)
+///     the 4 ms poll IS the frame pacing — producing frames only on
+///     wakeup events makes motion visibly choppier and adds a poll
+///     interval of input latency, and the focused surface is the one
+///     the user is typing into. Only one surface is focused at a time
+///     (the host forwards focus via ghostty_surface_set_focus), so
+///     the continuous cost is bounded to a single window.
+///
+///   * Unfocused surfaces: event-driven — a frame is only produced
+///     when something asked for one (wakeup async, mailbox activity,
+///     or the periodic safety net). Background windows still update
+///     live on PTY output but stop presenting when idle, instead of
+///     burning 60+ fps on content nobody is interacting with.
+fn nativeRenderCycle(
+    self: *Thread,
+    last_blink: *u64,
+    last_forced: *u64,
+    now: u64,
+) void {
+    const had_messages = self.drainMailbox() catch |err| blk: {
         log.err("error draining mailbox err={}", .{err});
+        break :blk false;
+    };
 
     if (self.flags.cursor_blink_reset) {
         self.flags.cursor_blink_reset = false;
         last_blink.* = now;
     }
 
-    self.renderer.updateFrame(
-        self.state,
-        self.flags.cursor_blink_visible,
-    ) catch |err|
-        log.warn("error rendering err={}", .{err});
-
-    if (now - last_blink.* >= cursorBlinkInterval()) {
+    // Toggle the blinking cursor while focused. Mirrors the xev branch,
+    // which cancels the cursor timer on focus loss; the .focus mailbox
+    // handler already resets cursor_blink_visible on both transitions.
+    var blink_toggled = false;
+    if (self.flags.focused and now - last_blink.* >= cursorBlinkInterval()) {
         self.flags.cursor_blink_visible = !self.flags.cursor_blink_visible;
         last_blink.* = now;
+        blink_toggled = true;
     }
 
-    self.drawFrame(false);
+    // Safety net: periodically force a full update+draw in case a
+    // producer's wakeup notify was dropped (mailbox pushes and notifies
+    // can fail independently), so a lost notify degrades to a briefly
+    // stale frame instead of a permanently stale one.
+    const forced = now - last_forced.* >= NATIVE_FORCED_REDRAW_INTERVAL;
+
+    // Focused surface renders unconditionally — see the doc comment.
+    const continuous = self.flags.focused;
+
+    if (continuous or self.flags.render_requested or had_messages or blink_toggled or forced) {
+        self.flags.render_requested = false;
+        last_forced.* = now;
+        self.renderer.updateFrame(
+            self.state,
+            self.flags.cursor_blink_visible,
+        ) catch |err|
+            log.warn("error rendering err={}", .{err});
+        self.drawFrame(false);
+        return;
+    }
+
+    // Custom-shader animations need continuous draws without a state
+    // update — the native-loop equivalent of the xev draw timer, which
+    // is never armed on this path.
+    if (self.flags.draw_now_requested or self.animationsActive()) {
+        const force = self.flags.draw_now_requested;
+        self.flags.draw_now_requested = false;
+        self.drawFrame(force);
+    }
+}
+
+/// Whether custom-shader animation wants continuous draws right now.
+/// Same policy as syncDrawTimer, which drives the xev draw timer.
+fn animationsActive(self: *Thread) bool {
+    if (comptime !@hasDecl(rendererpkg.Renderer, "hasAnimations")) return false;
+    if (!self.renderer.hasAnimations()) return false;
+    return switch (self.config.custom_shader_animation) {
+        .always => true,
+        .true => self.flags.focused,
+        .false => false,
+    };
 }
 
 fn wakeupCallback(
@@ -640,9 +738,18 @@ fn wakeupCallback(
 
     const t = self_.?;
 
+    // Native loop: defer all render work to nativeRenderCycle so no
+    // D3D calls happen inside xev callback dispatch (this backend's
+    // IOCP loop has a history of stalling around D3D11 work). The
+    // cycle picks the flag up within one poll interval.
+    if (comptime use_native_loop) {
+        t.flags.render_requested = true;
+        return .rearm;
+    }
+
     // When we wake up, we check the mailbox. Mailbox producers should
     // wake up our thread after publishing.
-    t.drainMailbox() catch |err|
+    _ = t.drainMailbox() catch |err|
         log.err("error draining mailbox err={}", .{err});
 
     // Render immediately
@@ -681,6 +788,14 @@ fn drawNowCallback(
 
     // Draw immediately
     const t = self_.?;
+
+    // Native loop: same deferral as wakeupCallback — keep D3D work
+    // out of xev dispatch.
+    if (comptime use_native_loop) {
+        t.flags.draw_now_requested = true;
+        return .rearm;
+    }
+
     t.drawFrame(true);
 
     return .rearm;

--- a/src/renderer/directx/Frame.zig
+++ b/src/renderer/directx/Frame.zig
@@ -7,6 +7,8 @@ const RenderPass = @import("RenderPass.zig");
 
 const Self = @This();
 
+const log = std.log.scoped(.directx);
+
 renderer: *Renderer,
 target: *Target,
 
@@ -26,6 +28,14 @@ pub fn renderPass(self: *const Self, attachments: []const RenderPass.Options.Att
 
 pub fn complete(self: *const Self, sync: bool) void {
     _ = sync;
+    // Hand the completed target to the API. For DirectX this is the
+    // "a full frame really was drawn" signal that arms the Present in
+    // drawFrameEnd — without it, drawFrameEnd would present the
+    // cleared-black backbuffer on paths that skip drawing (no-redraw,
+    // zero-size, synchronized-output). Mirrors opengl/Frame.zig.
+    self.renderer.api.present(self.target.*) catch |err| {
+        log.err("failed to present render target err={}", .{err});
+    };
     // Report frame health and release the swap chain semaphore.
     // Without this, the semaphore exhausts after swap_chain_count frames
     // and nextFrame() blocks forever.


### PR DESCRIPTION
## Why

Two problems in the native DirectX render loop:

1. The native branch never registered the `wakeup` / `draw_now` asyncs (only the xev branch does), so every `renderer_wakeup.notify()` from termio/Surface was silently dropped. The loop compensated by unconditionally rendering + presenting every 4/16 ms for every surface, focused or not, visible or not.
2. During synchronized output (mode 2026) and other skip-drawing paths, the deferred `drawFrameEnd` presented a backbuffer containing only the `drawFrameStart` clear — visible black flashes in fzf/nvim.

<details><summary>日本語</summary>

native DirectX render loop の2つの問題:

1. native 分岐は `wakeup` / `draw_now` async を登録しておらず (xev 分岐のみ)、termio/Surface からの `renderer_wakeup.notify()` がすべて捨てられていた。ループは focused/visible に関係なく全 surface を 4/16ms ごとに無条件レンダリング+Present することでこれを埋め合わせていた。
2. synchronized output (mode 2026) 等の描画スキップ経路で、defer された `drawFrameEnd` が `drawFrameStart` のクリアだけのバックバッファを Present していた — fzf/nvim での黒フラッシュ。

</details>

## What was done

**Commit 1 — DirectX: present only when a frame was actually drawn**
`Frame.complete` now calls `api.present` (mirroring the OpenGL backend), setting a `frame_drawn` flag; `drawFrameEnd` presents (and fires the first-present ready callback) only when set. Fixes the black-frame presents.

**Commit 2 — renderer: hybrid cadence**
- Register `wakeup` / `draw_now` on the polled loop (same delivery mechanism as the already-working stop async; callbacks only set flags — no D3D work inside xev dispatch).
- **Focused surface: renders every cycle, unchanged.** On a 240 Hz monitor the 4 ms poll is the frame pacing; event-only rendering measurably degraded typing feel. Only one surface is focused at a time (host forwards focus via `ghostty_surface_set_focus`).
- **Unfocused surfaces: event-driven** — render on wakeup / mailbox activity / 1 s safety net. Background windows still update live on PTY output but stop presenting when idle. Cursor blink ticks only while focused (xev-branch parity).

Note: an earlier iteration made every surface event-driven on the theory that continuous presents drove DWM/MPO flicker with overlapping windows; the flicker turned out to be a host-side window-activation feedback loop (fixed in GhosttyWin32#92), and A/B testing showed the event-only cadence hurt high-refresh feel, so the focused surface keeps the continuous cadence.

<details><summary>日本語</summary>

**Commit 1 — DirectX: 実際に描画したフレームのみ Present**
`Frame.complete` が `api.present` を呼び (OpenGL バックエンドのミラー)、`frame_drawn` フラグを立てる。`drawFrameEnd` はフラグがあるときだけ Present (+ 初回 ready callback 発火)。黒フレーム Present を修正。

**Commit 2 — renderer: ハイブリッド周期**
- `wakeup` / `draw_now` をポーリング対象 loop に登録 (実績ある stop async と同一メカニズム。callback はフラグを立てるのみで xev ディスパッチ内で D3D を触らない)。
- **focused surface: 従来どおり毎サイクル描画。** 240Hz モニタでは 4ms ポーリングがそのままフレームペーシングであり、イベント駆動のみでは打鍵の体感が測定可能なレベルで悪化した。focused は常に1 surface のみ (`ghostty_surface_set_focus` でホストが転送)。
- **非 focused surface: イベント駆動** — wakeup / mailbox / 1秒セーフティネットで描画。バックグラウンドウインドウも PTY 出力があればライブ更新されるが、アイドル時は Present を停止。cursor blink は focused 時のみ (xev 分岐と同等)。

補足: 以前のイテレーションでは「重なったウインドウの常時 Present が DWM/MPO ちらつきの原因」という仮説で全 surface をイベント駆動にしたが、ちらつきの真因はホスト側の window activation フィードバックループ (GhosttyWin32#92 で修正) であり、A/B テストでイベント駆動のみは高リフレッシュレートで体感が悪化したため、focused surface は常時描画を維持。

</details>

## Verification

- [x] Two overlapping windows, idle: no flicker (with GhosttyWin32#92)
- [x] Typing feel on 240 Hz matches the pre-change loop (A/B tested)
- [ ] Background window updates live on PTY output while unfocused
- [ ] fzf / nvim: no black flashes
- [ ] Cursor blinks ~600 ms focused; stops unfocused
- [ ] IME preedit renders while composing; interactive resize tracks

<details><summary>日本語</summary>

- [x] 2ウインドウ重ねアイドル: ちらつきなし (GhosttyWin32#92 と併用)
- [x] 240Hz でのタイプ体感が変更前ループと同等 (A/B テスト済み)
- [ ] 非 focused のバックグラウンドウインドウが PTY 出力でライブ更新
- [ ] fzf / nvim: 黒フラッシュなし
- [ ] cursor blink: focused 時 ~600ms、非 focused 時停止
- [ ] IME 変換中の preedit 表示、インタラクティブリサイズ追従

</details>
